### PR TITLE
Replace status_t with mems_status_t

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
-name=LSM6DS3
-version=1.0.0
+name=STM32duino LSM6DS3
+version=1.0.1
 author=AST
 maintainer=stm32duino
 sentence=3D accelerometer and 3D gyroscope.

--- a/src/LSM6DS3_ACC_GYRO_driver.c
+++ b/src/LSM6DS3_ACC_GYRO_driver.c
@@ -65,7 +65,7 @@ extern uint8_t LSM6DS3_IO_Read(void *handle, uint8_t ReadAddr, uint8_t *pBuffer,
 * Output      : None
 * Return      : None
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_WriteReg(void *handle, u8_t Reg, u8_t *Bufp, u16_t len)
+mems_status_t LSM6DS3_ACC_GYRO_WriteReg(void *handle, u8_t Reg, u8_t *Bufp, u16_t len)
 {
 
   if (LSM6DS3_IO_Write(handle, Reg, Bufp, len))
@@ -87,7 +87,7 @@ status_t LSM6DS3_ACC_GYRO_WriteReg(void *handle, u8_t Reg, u8_t *Bufp, u16_t len
 * Output      : None
 * Return      : None
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_ReadReg(void *handle, u8_t Reg, u8_t *Bufp, u16_t len)
+mems_status_t LSM6DS3_ACC_GYRO_ReadReg(void *handle, u8_t Reg, u8_t *Bufp, u16_t len)
 {
 
   if (LSM6DS3_IO_Read(handle, Reg, Bufp, len))
@@ -109,7 +109,7 @@ status_t LSM6DS3_ACC_GYRO_ReadReg(void *handle, u8_t Reg, u8_t *Bufp, u16_t len)
 * Output         : Status of WHO_AM_I_BIT
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_WHO_AM_I(void *handle, u8_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_WHO_AM_I(void *handle, u8_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_WHO_AM_I_REG, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -127,7 +127,7 @@ status_t LSM6DS3_ACC_GYRO_R_WHO_AM_I(void *handle, u8_t *value)
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM6DS3_ACC_GYRO_W_BDU(void *handle, LSM6DS3_ACC_GYRO_BDU_t newValue)
+mems_status_t  LSM6DS3_ACC_GYRO_W_BDU(void *handle, LSM6DS3_ACC_GYRO_BDU_t newValue)
 {
   u8_t value;
 
@@ -150,7 +150,7 @@ status_t  LSM6DS3_ACC_GYRO_W_BDU(void *handle, LSM6DS3_ACC_GYRO_BDU_t newValue)
 * Output         : Status of BDU see LSM6DS3_ACC_GYRO_BDU_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_BDU(void *handle, LSM6DS3_ACC_GYRO_BDU_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_BDU(void *handle, LSM6DS3_ACC_GYRO_BDU_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_CTRL3_C, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -167,7 +167,7 @@ status_t LSM6DS3_ACC_GYRO_R_BDU(void *handle, LSM6DS3_ACC_GYRO_BDU_t *value)
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM6DS3_ACC_GYRO_W_FS_XL(void *handle, LSM6DS3_ACC_GYRO_FS_XL_t newValue)
+mems_status_t  LSM6DS3_ACC_GYRO_W_FS_XL(void *handle, LSM6DS3_ACC_GYRO_FS_XL_t newValue)
 {
   u8_t value;
 
@@ -190,7 +190,7 @@ status_t  LSM6DS3_ACC_GYRO_W_FS_XL(void *handle, LSM6DS3_ACC_GYRO_FS_XL_t newVal
 * Output         : Status of FS_XL see LSM6DS3_ACC_GYRO_FS_XL_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_FS_XL(void *handle, LSM6DS3_ACC_GYRO_FS_XL_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_FS_XL(void *handle, LSM6DS3_ACC_GYRO_FS_XL_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_CTRL1_XL, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -201,13 +201,13 @@ status_t LSM6DS3_ACC_GYRO_R_FS_XL(void *handle, LSM6DS3_ACC_GYRO_FS_XL_t *value)
 }
 
 /*******************************************************************************
-* Function Name  : status_t LSM6DS3_ACC_GYRO_GetRawAccData(u8_t *buff)
+* Function Name  : mems_status_t LSM6DS3_ACC_GYRO_GetRawAccData(u8_t *buff)
 * Description    : Read GetAccData output register
 * Input          : pointer to [u8_t]
 * Output         : GetAccData buffer u8_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_GetRawAccData(void *handle, u8_t *buff)
+mems_status_t LSM6DS3_ACC_GYRO_GetRawAccData(void *handle, u8_t *buff)
 {
   u8_t i, j, k;
   u8_t numberOfByteForDimension;
@@ -229,7 +229,7 @@ status_t LSM6DS3_ACC_GYRO_GetRawAccData(void *handle, u8_t *buff)
 }
 
 /*******************************************************************************
-* Function Name  : status_t LSM6DS3_ACC_Get_Acceleration(void *handle, int *buff, u8_t from_fifo)
+* Function Name  : mems_status_t LSM6DS3_ACC_Get_Acceleration(void *handle, int *buff, u8_t from_fifo)
 * Description    : Read GetAccData output register
 * Input          : pointer to [u8_t]
 * Output         : values are expressed in mg
@@ -246,7 +246,7 @@ static const long long LSM6DS3_ACC_Sensitivity_List[4] =
   244,  /* FS @8g */
   488,  /* FS @16g */
 };
-status_t LSM6DS3_ACC_Get_Acceleration(void *handle, int *buff, u8_t from_fifo)
+mems_status_t LSM6DS3_ACC_Get_Acceleration(void *handle, int *buff, u8_t from_fifo)
 {
   LSM6DS3_ACC_GYRO_FS_XL_t fs;
   long long sensitivity = 0;
@@ -302,7 +302,7 @@ status_t LSM6DS3_ACC_Get_Acceleration(void *handle, int *buff, u8_t from_fifo)
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM6DS3_ACC_GYRO_W_ODR_XL(void *handle, LSM6DS3_ACC_GYRO_ODR_XL_t newValue)
+mems_status_t  LSM6DS3_ACC_GYRO_W_ODR_XL(void *handle, LSM6DS3_ACC_GYRO_ODR_XL_t newValue)
 {
   u8_t value;
 
@@ -325,7 +325,7 @@ status_t  LSM6DS3_ACC_GYRO_W_ODR_XL(void *handle, LSM6DS3_ACC_GYRO_ODR_XL_t newV
 * Output         : Status of ODR_XL see LSM6DS3_ACC_GYRO_ODR_XL_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_ODR_XL(void *handle, LSM6DS3_ACC_GYRO_ODR_XL_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_ODR_XL(void *handle, LSM6DS3_ACC_GYRO_ODR_XL_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_CTRL1_XL, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -342,7 +342,7 @@ status_t LSM6DS3_ACC_GYRO_R_ODR_XL(void *handle, LSM6DS3_ACC_GYRO_ODR_XL_t *valu
 * Output         : The ODR value in Hz
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_translate_ODR_XL(LSM6DS3_ACC_GYRO_ODR_XL_t value, u16_t *odr_hz_val)
+mems_status_t LSM6DS3_ACC_GYRO_translate_ODR_XL(LSM6DS3_ACC_GYRO_ODR_XL_t value, u16_t *odr_hz_val)
 {
   switch(value)
   {
@@ -396,7 +396,7 @@ status_t LSM6DS3_ACC_GYRO_translate_ODR_XL(LSM6DS3_ACC_GYRO_ODR_XL_t value, u16_
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM6DS3_ACC_GYRO_W_FS_G(void *handle, LSM6DS3_ACC_GYRO_FS_G_t newValue)
+mems_status_t  LSM6DS3_ACC_GYRO_W_FS_G(void *handle, LSM6DS3_ACC_GYRO_FS_G_t newValue)
 {
   u8_t value;
 
@@ -419,7 +419,7 @@ status_t  LSM6DS3_ACC_GYRO_W_FS_G(void *handle, LSM6DS3_ACC_GYRO_FS_G_t newValue
 * Output         : Status of FS_G see LSM6DS3_ACC_GYRO_FS_G_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_FS_G(void *handle, LSM6DS3_ACC_GYRO_FS_G_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_FS_G(void *handle, LSM6DS3_ACC_GYRO_FS_G_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_CTRL2_G, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -436,7 +436,7 @@ status_t LSM6DS3_ACC_GYRO_R_FS_G(void *handle, LSM6DS3_ACC_GYRO_FS_G_t *value)
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM6DS3_ACC_GYRO_W_ODR_G(void *handle, LSM6DS3_ACC_GYRO_ODR_G_t newValue)
+mems_status_t  LSM6DS3_ACC_GYRO_W_ODR_G(void *handle, LSM6DS3_ACC_GYRO_ODR_G_t newValue)
 {
   u8_t value;
 
@@ -459,7 +459,7 @@ status_t  LSM6DS3_ACC_GYRO_W_ODR_G(void *handle, LSM6DS3_ACC_GYRO_ODR_G_t newVal
 * Output         : Status of ODR_G see LSM6DS3_ACC_GYRO_ODR_G_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_ODR_G(void *handle, LSM6DS3_ACC_GYRO_ODR_G_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_ODR_G(void *handle, LSM6DS3_ACC_GYRO_ODR_G_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_CTRL2_G, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -476,7 +476,7 @@ status_t LSM6DS3_ACC_GYRO_R_ODR_G(void *handle, LSM6DS3_ACC_GYRO_ODR_G_t *value)
 * Output         : The ODR value in Hz
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_translate_ODR_G(LSM6DS3_ACC_GYRO_ODR_G_t value, u16_t *odr_hz_val)
+mems_status_t LSM6DS3_ACC_GYRO_translate_ODR_G(LSM6DS3_ACC_GYRO_ODR_G_t value, u16_t *odr_hz_val)
 {
   switch(value)
   {
@@ -524,13 +524,13 @@ status_t LSM6DS3_ACC_GYRO_translate_ODR_G(LSM6DS3_ACC_GYRO_ODR_G_t value, u16_t 
 }
 
 /*******************************************************************************
-* Function Name  : status_t LSM6DS3_ACC_GYRO_GetRawGyroData(u8_t *buff)
+* Function Name  : mems_status_t LSM6DS3_ACC_GYRO_GetRawGyroData(u8_t *buff)
 * Description    : Read GetGyroData output register
 * Input          : pointer to [u8_t]
 * Output         : GetGyroData buffer u8_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_GetRawGyroData(void *handle, u8_t *buff)
+mems_status_t LSM6DS3_ACC_GYRO_GetRawGyroData(void *handle, u8_t *buff)
 {
   u8_t i, j, k;
   u8_t numberOfByteForDimension;
@@ -552,7 +552,7 @@ status_t LSM6DS3_ACC_GYRO_GetRawGyroData(void *handle, u8_t *buff)
 }
 
 /*******************************************************************************
-* Function Name  : status_t LSM6DS3_ACC_Get_AngularRate(u8_t *buff)
+* Function Name  : mems_status_t LSM6DS3_ACC_Get_AngularRate(u8_t *buff)
 * Description    : Read GetGyroData output register
 * Input          : pointer to [u8_t]
 * Output         : Returned values are espressed in mdps
@@ -570,7 +570,7 @@ static const long long LSM6DS3_GYRO_Sensitivity_List[5] =
   35000,  /* FS @1000 */
   70000,  /* FS @2000 */
 };
-status_t LSM6DS3_ACC_Get_AngularRate(void *handle, int *buff, u8_t from_fifo)
+mems_status_t LSM6DS3_ACC_Get_AngularRate(void *handle, int *buff, u8_t from_fifo)
 {
   LSM6DS3_ACC_GYRO_FS_125_t fs_125;
   LSM6DS3_ACC_GYRO_FS_G_t fs;
@@ -635,7 +635,7 @@ status_t LSM6DS3_ACC_Get_AngularRate(void *handle, int *buff, u8_t from_fifo)
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM6DS3_ACC_GYRO_W_BW_XL(void *handle, LSM6DS3_ACC_GYRO_BW_XL_t newValue)
+mems_status_t  LSM6DS3_ACC_GYRO_W_BW_XL(void *handle, LSM6DS3_ACC_GYRO_BW_XL_t newValue)
 {
   u8_t value;
 
@@ -658,7 +658,7 @@ status_t  LSM6DS3_ACC_GYRO_W_BW_XL(void *handle, LSM6DS3_ACC_GYRO_BW_XL_t newVal
 * Output         : Status of BW_XL see LSM6DS3_ACC_GYRO_BW_XL_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_BW_XL(void *handle, LSM6DS3_ACC_GYRO_BW_XL_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_BW_XL(void *handle, LSM6DS3_ACC_GYRO_BW_XL_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_CTRL1_XL, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -675,7 +675,7 @@ status_t LSM6DS3_ACC_GYRO_R_BW_XL(void *handle, LSM6DS3_ACC_GYRO_BW_XL_t *value)
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM6DS3_ACC_GYRO_W_FS_125(void *handle, LSM6DS3_ACC_GYRO_FS_125_t newValue)
+mems_status_t  LSM6DS3_ACC_GYRO_W_FS_125(void *handle, LSM6DS3_ACC_GYRO_FS_125_t newValue)
 {
   u8_t value;
 
@@ -698,7 +698,7 @@ status_t  LSM6DS3_ACC_GYRO_W_FS_125(void *handle, LSM6DS3_ACC_GYRO_FS_125_t newV
 * Output         : Status of FS_125 see LSM6DS3_ACC_GYRO_FS_125_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_FS_125(void *handle, LSM6DS3_ACC_GYRO_FS_125_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_FS_125(void *handle, LSM6DS3_ACC_GYRO_FS_125_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_CTRL2_G, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -717,7 +717,7 @@ status_t LSM6DS3_ACC_GYRO_R_FS_125(void *handle, LSM6DS3_ACC_GYRO_FS_125_t *valu
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM6DS3_ACC_GYRO_W_EmbeddedAccess(void *handle, LSM6DS3_ACC_GYRO_EMB_ACC_t newValue)
+mems_status_t  LSM6DS3_ACC_GYRO_W_EmbeddedAccess(void *handle, LSM6DS3_ACC_GYRO_EMB_ACC_t newValue)
 {
   u8_t value;
 
@@ -740,7 +740,7 @@ status_t  LSM6DS3_ACC_GYRO_W_EmbeddedAccess(void *handle, LSM6DS3_ACC_GYRO_EMB_A
 * Output         : Status of FUNC_CFG_EN see LSM6DS3_ACC_GYRO_EMB_ACC_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_EmbeddedAccess(void *handle, LSM6DS3_ACC_GYRO_EMB_ACC_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_EmbeddedAccess(void *handle, LSM6DS3_ACC_GYRO_EMB_ACC_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_FUNC_CFG_ACCESS, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -757,7 +757,7 @@ status_t LSM6DS3_ACC_GYRO_R_EmbeddedAccess(void *handle, LSM6DS3_ACC_GYRO_EMB_AC
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM6DS3_ACC_GYRO_W_Stamping_Time_Frame(void *handle, u8_t newValue)
+mems_status_t  LSM6DS3_ACC_GYRO_W_Stamping_Time_Frame(void *handle, u8_t newValue)
 {
   u8_t value;
 
@@ -783,7 +783,7 @@ status_t  LSM6DS3_ACC_GYRO_W_Stamping_Time_Frame(void *handle, u8_t newValue)
 * Output         : Status of TPH
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_Stamping_Time_Frame(void *handle, u8_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_Stamping_Time_Frame(void *handle, u8_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_SENSOR_SYNC_TIME, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -801,7 +801,7 @@ status_t LSM6DS3_ACC_GYRO_R_Stamping_Time_Frame(void *handle, u8_t *value)
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM6DS3_ACC_GYRO_W_FIFO_Watermark(void *handle, u16_t newValue)
+mems_status_t  LSM6DS3_ACC_GYRO_W_FIFO_Watermark(void *handle, u16_t newValue)
 {
   u8_t valueH, valueL;
   u8_t value;
@@ -845,7 +845,7 @@ status_t  LSM6DS3_ACC_GYRO_W_FIFO_Watermark(void *handle, u16_t newValue)
 * Output         : Status of WTM_FIFO
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_FIFO_Watermark(void *handle, u16_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_FIFO_Watermark(void *handle, u16_t *value)
 {
   u8_t valueH, valueL;
 
@@ -875,7 +875,7 @@ status_t LSM6DS3_ACC_GYRO_R_FIFO_Watermark(void *handle, u16_t *value)
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM6DS3_ACC_GYRO_W_TIM_PEDO_FIFO_Write_En(void *handle, LSM6DS3_ACC_GYRO_TIM_PEDO_FIFO_DRDY_t newValue)
+mems_status_t  LSM6DS3_ACC_GYRO_W_TIM_PEDO_FIFO_Write_En(void *handle, LSM6DS3_ACC_GYRO_TIM_PEDO_FIFO_DRDY_t newValue)
 {
   u8_t value;
 
@@ -898,7 +898,7 @@ status_t  LSM6DS3_ACC_GYRO_W_TIM_PEDO_FIFO_Write_En(void *handle, LSM6DS3_ACC_GY
 * Output         : Status of TIM_PEDO_FIFO_DRDY see LSM6DS3_ACC_GYRO_TIM_PEDO_FIFO_DRDY_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_TIM_PEDO_FIFO_Write_En(void *handle, LSM6DS3_ACC_GYRO_TIM_PEDO_FIFO_DRDY_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_TIM_PEDO_FIFO_Write_En(void *handle, LSM6DS3_ACC_GYRO_TIM_PEDO_FIFO_DRDY_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_FIFO_CTRL2, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -914,7 +914,7 @@ status_t LSM6DS3_ACC_GYRO_R_TIM_PEDO_FIFO_Write_En(void *handle, LSM6DS3_ACC_GYR
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM6DS3_ACC_GYRO_W_TIM_PEDO_FIFO_En(void *handle, LSM6DS3_ACC_GYRO_TIM_PEDO_FIFO_EN_t newValue)
+mems_status_t  LSM6DS3_ACC_GYRO_W_TIM_PEDO_FIFO_En(void *handle, LSM6DS3_ACC_GYRO_TIM_PEDO_FIFO_EN_t newValue)
 {
   u8_t value;
 
@@ -937,7 +937,7 @@ status_t  LSM6DS3_ACC_GYRO_W_TIM_PEDO_FIFO_En(void *handle, LSM6DS3_ACC_GYRO_TIM
 * Output         : Status of TIM_PEDO_FIFO_EN see LSM6DS3_ACC_GYRO_TIM_PEDO_FIFO_EN_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_TIM_PEDO_FIFO_En(void *handle, LSM6DS3_ACC_GYRO_TIM_PEDO_FIFO_EN_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_TIM_PEDO_FIFO_En(void *handle, LSM6DS3_ACC_GYRO_TIM_PEDO_FIFO_EN_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_FIFO_CTRL2, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -953,7 +953,7 @@ status_t LSM6DS3_ACC_GYRO_R_TIM_PEDO_FIFO_En(void *handle, LSM6DS3_ACC_GYRO_TIM_
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM6DS3_ACC_GYRO_W_DEC_FIFO_XL(void *handle, LSM6DS3_ACC_GYRO_DEC_FIFO_XL_t newValue)
+mems_status_t  LSM6DS3_ACC_GYRO_W_DEC_FIFO_XL(void *handle, LSM6DS3_ACC_GYRO_DEC_FIFO_XL_t newValue)
 {
   u8_t value;
 
@@ -976,7 +976,7 @@ status_t  LSM6DS3_ACC_GYRO_W_DEC_FIFO_XL(void *handle, LSM6DS3_ACC_GYRO_DEC_FIFO
 * Output         : Program XL decimation value from unsigned short
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM6DS3_ACC_GYRO_W_DEC_FIFO_XL_val(void *handle, u16_t newValue)
+mems_status_t  LSM6DS3_ACC_GYRO_W_DEC_FIFO_XL_val(void *handle, u16_t newValue)
 {
   switch(newValue)
   {
@@ -1026,7 +1026,7 @@ status_t  LSM6DS3_ACC_GYRO_W_DEC_FIFO_XL_val(void *handle, u16_t newValue)
 * Output         : Status of DEC_FIFO_XL see LSM6DS3_ACC_GYRO_DEC_FIFO_XL_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_DEC_FIFO_XL(void *handle, LSM6DS3_ACC_GYRO_DEC_FIFO_XL_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_DEC_FIFO_XL(void *handle, LSM6DS3_ACC_GYRO_DEC_FIFO_XL_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_FIFO_CTRL3, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -1043,7 +1043,7 @@ status_t LSM6DS3_ACC_GYRO_R_DEC_FIFO_XL(void *handle, LSM6DS3_ACC_GYRO_DEC_FIFO_
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM6DS3_ACC_GYRO_W_DEC_FIFO_G(void *handle, LSM6DS3_ACC_GYRO_DEC_FIFO_G_t newValue)
+mems_status_t  LSM6DS3_ACC_GYRO_W_DEC_FIFO_G(void *handle, LSM6DS3_ACC_GYRO_DEC_FIFO_G_t newValue)
 {
   u8_t value;
 
@@ -1066,7 +1066,7 @@ status_t  LSM6DS3_ACC_GYRO_W_DEC_FIFO_G(void *handle, LSM6DS3_ACC_GYRO_DEC_FIFO_
 * Output         : Program G decimation value from unsigned short
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM6DS3_ACC_GYRO_W_DEC_FIFO_G_val(void *handle, u16_t newValue)
+mems_status_t  LSM6DS3_ACC_GYRO_W_DEC_FIFO_G_val(void *handle, u16_t newValue)
 {
   switch(newValue)
   {
@@ -1116,7 +1116,7 @@ status_t  LSM6DS3_ACC_GYRO_W_DEC_FIFO_G_val(void *handle, u16_t newValue)
 * Output         : Status of DEC_FIFO_G see LSM6DS3_ACC_GYRO_DEC_FIFO_G_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_DEC_FIFO_G(void *handle, LSM6DS3_ACC_GYRO_DEC_FIFO_G_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_DEC_FIFO_G(void *handle, LSM6DS3_ACC_GYRO_DEC_FIFO_G_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_FIFO_CTRL3, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -1133,7 +1133,7 @@ status_t LSM6DS3_ACC_GYRO_R_DEC_FIFO_G(void *handle, LSM6DS3_ACC_GYRO_DEC_FIFO_G
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM6DS3_ACC_GYRO_W_DEC_FIFO_SLV0(void *handle, LSM6DS3_ACC_GYRO_DEC_FIFO_SLV0_t newValue)
+mems_status_t  LSM6DS3_ACC_GYRO_W_DEC_FIFO_SLV0(void *handle, LSM6DS3_ACC_GYRO_DEC_FIFO_SLV0_t newValue)
 {
   u8_t value;
 
@@ -1156,7 +1156,7 @@ status_t  LSM6DS3_ACC_GYRO_W_DEC_FIFO_SLV0(void *handle, LSM6DS3_ACC_GYRO_DEC_FI
 * Output         : Status of DEC_FIFO_SLV0 see LSM6DS3_ACC_GYRO_DEC_FIFO_SLV0_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_DEC_FIFO_SLV0(void *handle, LSM6DS3_ACC_GYRO_DEC_FIFO_SLV0_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_DEC_FIFO_SLV0(void *handle, LSM6DS3_ACC_GYRO_DEC_FIFO_SLV0_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_FIFO_CTRL4, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -1173,7 +1173,7 @@ status_t LSM6DS3_ACC_GYRO_R_DEC_FIFO_SLV0(void *handle, LSM6DS3_ACC_GYRO_DEC_FIF
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM6DS3_ACC_GYRO_W_DEC_FIFO_SLV1(void *handle, LSM6DS3_ACC_GYRO_DEC_FIFO_SLV1_t newValue)
+mems_status_t  LSM6DS3_ACC_GYRO_W_DEC_FIFO_SLV1(void *handle, LSM6DS3_ACC_GYRO_DEC_FIFO_SLV1_t newValue)
 {
   u8_t value;
 
@@ -1196,7 +1196,7 @@ status_t  LSM6DS3_ACC_GYRO_W_DEC_FIFO_SLV1(void *handle, LSM6DS3_ACC_GYRO_DEC_FI
 * Output         : Status of DEC_FIFO_SLV1 see LSM6DS3_ACC_GYRO_DEC_FIFO_SLV1_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_DEC_FIFO_SLV1(void *handle, LSM6DS3_ACC_GYRO_DEC_FIFO_SLV1_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_DEC_FIFO_SLV1(void *handle, LSM6DS3_ACC_GYRO_DEC_FIFO_SLV1_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_FIFO_CTRL4, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -1213,7 +1213,7 @@ status_t LSM6DS3_ACC_GYRO_R_DEC_FIFO_SLV1(void *handle, LSM6DS3_ACC_GYRO_DEC_FIF
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM6DS3_ACC_GYRO_W_HI_DATA_ONLY(void *handle, LSM6DS3_ACC_GYRO_HI_DATA_ONLY_t newValue)
+mems_status_t  LSM6DS3_ACC_GYRO_W_HI_DATA_ONLY(void *handle, LSM6DS3_ACC_GYRO_HI_DATA_ONLY_t newValue)
 {
   u8_t value;
 
@@ -1236,7 +1236,7 @@ status_t  LSM6DS3_ACC_GYRO_W_HI_DATA_ONLY(void *handle, LSM6DS3_ACC_GYRO_HI_DATA
 * Output         : Status of HI_DATA_ONLY see LSM6DS3_ACC_GYRO_HI_DATA_ONLY_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_HI_DATA_ONLY(void *handle, LSM6DS3_ACC_GYRO_HI_DATA_ONLY_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_HI_DATA_ONLY(void *handle, LSM6DS3_ACC_GYRO_HI_DATA_ONLY_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_FIFO_CTRL4, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -1253,7 +1253,7 @@ status_t LSM6DS3_ACC_GYRO_R_HI_DATA_ONLY(void *handle, LSM6DS3_ACC_GYRO_HI_DATA_
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM6DS3_ACC_GYRO_W_FIFO_MODE(void *handle, LSM6DS3_ACC_GYRO_FIFO_MODE_t newValue)
+mems_status_t  LSM6DS3_ACC_GYRO_W_FIFO_MODE(void *handle, LSM6DS3_ACC_GYRO_FIFO_MODE_t newValue)
 {
   u8_t value;
 
@@ -1276,7 +1276,7 @@ status_t  LSM6DS3_ACC_GYRO_W_FIFO_MODE(void *handle, LSM6DS3_ACC_GYRO_FIFO_MODE_
 * Output         : Status of FIFO_MODE see LSM6DS3_ACC_GYRO_FIFO_MODE_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_FIFO_MODE(void *handle, LSM6DS3_ACC_GYRO_FIFO_MODE_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_FIFO_MODE(void *handle, LSM6DS3_ACC_GYRO_FIFO_MODE_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_FIFO_CTRL5, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -1293,7 +1293,7 @@ status_t LSM6DS3_ACC_GYRO_R_FIFO_MODE(void *handle, LSM6DS3_ACC_GYRO_FIFO_MODE_t
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM6DS3_ACC_GYRO_W_ODR_FIFO(void *handle, LSM6DS3_ACC_GYRO_ODR_FIFO_t newValue)
+mems_status_t  LSM6DS3_ACC_GYRO_W_ODR_FIFO(void *handle, LSM6DS3_ACC_GYRO_ODR_FIFO_t newValue)
 {
   u8_t value;
 
@@ -1316,7 +1316,7 @@ status_t  LSM6DS3_ACC_GYRO_W_ODR_FIFO(void *handle, LSM6DS3_ACC_GYRO_ODR_FIFO_t 
 * Output         : Status of ODR_FIFO see LSM6DS3_ACC_GYRO_ODR_FIFO_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_ODR_FIFO(void *handle, LSM6DS3_ACC_GYRO_ODR_FIFO_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_ODR_FIFO(void *handle, LSM6DS3_ACC_GYRO_ODR_FIFO_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_FIFO_CTRL5, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -1333,7 +1333,7 @@ status_t LSM6DS3_ACC_GYRO_R_ODR_FIFO(void *handle, LSM6DS3_ACC_GYRO_ODR_FIFO_t *
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM6DS3_ACC_GYRO_W_Orientation(void *handle, LSM6DS3_ACC_GYRO_ORIENT_t newValue)
+mems_status_t  LSM6DS3_ACC_GYRO_W_Orientation(void *handle, LSM6DS3_ACC_GYRO_ORIENT_t newValue)
 {
   u8_t value;
 
@@ -1356,7 +1356,7 @@ status_t  LSM6DS3_ACC_GYRO_W_Orientation(void *handle, LSM6DS3_ACC_GYRO_ORIENT_t
 * Output         : Status of ORIENT see LSM6DS3_ACC_GYRO_ORIENT_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_Orientation(void *handle, LSM6DS3_ACC_GYRO_ORIENT_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_Orientation(void *handle, LSM6DS3_ACC_GYRO_ORIENT_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_ORIENT_CFG_G, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -1373,7 +1373,7 @@ status_t LSM6DS3_ACC_GYRO_R_Orientation(void *handle, LSM6DS3_ACC_GYRO_ORIENT_t 
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM6DS3_ACC_GYRO_W_SignZ_G(void *handle, LSM6DS3_ACC_GYRO_SIGN_Z_G_t newValue)
+mems_status_t  LSM6DS3_ACC_GYRO_W_SignZ_G(void *handle, LSM6DS3_ACC_GYRO_SIGN_Z_G_t newValue)
 {
   u8_t value;
 
@@ -1396,7 +1396,7 @@ status_t  LSM6DS3_ACC_GYRO_W_SignZ_G(void *handle, LSM6DS3_ACC_GYRO_SIGN_Z_G_t n
 * Output         : Status of SIGN_Z_G see LSM6DS3_ACC_GYRO_SIGN_Z_G_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_SignZ_G(void *handle, LSM6DS3_ACC_GYRO_SIGN_Z_G_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_SignZ_G(void *handle, LSM6DS3_ACC_GYRO_SIGN_Z_G_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_ORIENT_CFG_G, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -1413,7 +1413,7 @@ status_t LSM6DS3_ACC_GYRO_R_SignZ_G(void *handle, LSM6DS3_ACC_GYRO_SIGN_Z_G_t *v
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM6DS3_ACC_GYRO_W_SignY_G(void *handle, LSM6DS3_ACC_GYRO_SIGN_Y_G_t newValue)
+mems_status_t  LSM6DS3_ACC_GYRO_W_SignY_G(void *handle, LSM6DS3_ACC_GYRO_SIGN_Y_G_t newValue)
 {
   u8_t value;
 
@@ -1436,7 +1436,7 @@ status_t  LSM6DS3_ACC_GYRO_W_SignY_G(void *handle, LSM6DS3_ACC_GYRO_SIGN_Y_G_t n
 * Output         : Status of SIGN_Y_G see LSM6DS3_ACC_GYRO_SIGN_Y_G_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_SignY_G(void *handle, LSM6DS3_ACC_GYRO_SIGN_Y_G_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_SignY_G(void *handle, LSM6DS3_ACC_GYRO_SIGN_Y_G_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_ORIENT_CFG_G, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -1453,7 +1453,7 @@ status_t LSM6DS3_ACC_GYRO_R_SignY_G(void *handle, LSM6DS3_ACC_GYRO_SIGN_Y_G_t *v
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM6DS3_ACC_GYRO_W_SignX_G(void *handle, LSM6DS3_ACC_GYRO_SIGN_X_G_t newValue)
+mems_status_t  LSM6DS3_ACC_GYRO_W_SignX_G(void *handle, LSM6DS3_ACC_GYRO_SIGN_X_G_t newValue)
 {
   u8_t value;
 
@@ -1476,7 +1476,7 @@ status_t  LSM6DS3_ACC_GYRO_W_SignX_G(void *handle, LSM6DS3_ACC_GYRO_SIGN_X_G_t n
 * Output         : Status of SIGN_X_G see LSM6DS3_ACC_GYRO_SIGN_X_G_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_SignX_G(void *handle, LSM6DS3_ACC_GYRO_SIGN_X_G_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_SignX_G(void *handle, LSM6DS3_ACC_GYRO_SIGN_X_G_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_ORIENT_CFG_G, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -1493,7 +1493,7 @@ status_t LSM6DS3_ACC_GYRO_R_SignX_G(void *handle, LSM6DS3_ACC_GYRO_SIGN_X_G_t *v
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM6DS3_ACC_GYRO_W_DRDY_XL_on_INT1(void *handle, LSM6DS3_ACC_GYRO_INT1_DRDY_XL_t newValue)
+mems_status_t  LSM6DS3_ACC_GYRO_W_DRDY_XL_on_INT1(void *handle, LSM6DS3_ACC_GYRO_INT1_DRDY_XL_t newValue)
 {
   u8_t value;
 
@@ -1516,7 +1516,7 @@ status_t  LSM6DS3_ACC_GYRO_W_DRDY_XL_on_INT1(void *handle, LSM6DS3_ACC_GYRO_INT1
 * Output         : Status of INT1_DRDY_XL see LSM6DS3_ACC_GYRO_INT1_DRDY_XL_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_DRDY_XL_on_INT1(void *handle, LSM6DS3_ACC_GYRO_INT1_DRDY_XL_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_DRDY_XL_on_INT1(void *handle, LSM6DS3_ACC_GYRO_INT1_DRDY_XL_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_INT1_CTRL, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -1533,7 +1533,7 @@ status_t LSM6DS3_ACC_GYRO_R_DRDY_XL_on_INT1(void *handle, LSM6DS3_ACC_GYRO_INT1_
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM6DS3_ACC_GYRO_W_DRDY_G_on_INT1(void *handle, LSM6DS3_ACC_GYRO_INT1_DRDY_G_t newValue)
+mems_status_t  LSM6DS3_ACC_GYRO_W_DRDY_G_on_INT1(void *handle, LSM6DS3_ACC_GYRO_INT1_DRDY_G_t newValue)
 {
   u8_t value;
 
@@ -1556,7 +1556,7 @@ status_t  LSM6DS3_ACC_GYRO_W_DRDY_G_on_INT1(void *handle, LSM6DS3_ACC_GYRO_INT1_
 * Output         : Status of INT1_DRDY_G see LSM6DS3_ACC_GYRO_INT1_DRDY_G_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_DRDY_G_on_INT1(void *handle, LSM6DS3_ACC_GYRO_INT1_DRDY_G_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_DRDY_G_on_INT1(void *handle, LSM6DS3_ACC_GYRO_INT1_DRDY_G_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_INT1_CTRL, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -1573,7 +1573,7 @@ status_t LSM6DS3_ACC_GYRO_R_DRDY_G_on_INT1(void *handle, LSM6DS3_ACC_GYRO_INT1_D
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM6DS3_ACC_GYRO_W_BOOT_on_INT1(void *handle, LSM6DS3_ACC_GYRO_INT1_BOOT_t newValue)
+mems_status_t  LSM6DS3_ACC_GYRO_W_BOOT_on_INT1(void *handle, LSM6DS3_ACC_GYRO_INT1_BOOT_t newValue)
 {
   u8_t value;
 
@@ -1596,7 +1596,7 @@ status_t  LSM6DS3_ACC_GYRO_W_BOOT_on_INT1(void *handle, LSM6DS3_ACC_GYRO_INT1_BO
 * Output         : Status of INT1_BOOT see LSM6DS3_ACC_GYRO_INT1_BOOT_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_BOOT_on_INT1(void *handle, LSM6DS3_ACC_GYRO_INT1_BOOT_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_BOOT_on_INT1(void *handle, LSM6DS3_ACC_GYRO_INT1_BOOT_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_INT1_CTRL, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -1613,7 +1613,7 @@ status_t LSM6DS3_ACC_GYRO_R_BOOT_on_INT1(void *handle, LSM6DS3_ACC_GYRO_INT1_BOO
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM6DS3_ACC_GYRO_W_FIFO_TSHLD_on_INT1(void *handle, LSM6DS3_ACC_GYRO_INT1_FTH_t newValue)
+mems_status_t  LSM6DS3_ACC_GYRO_W_FIFO_TSHLD_on_INT1(void *handle, LSM6DS3_ACC_GYRO_INT1_FTH_t newValue)
 {
   u8_t value;
 
@@ -1636,7 +1636,7 @@ status_t  LSM6DS3_ACC_GYRO_W_FIFO_TSHLD_on_INT1(void *handle, LSM6DS3_ACC_GYRO_I
 * Output         : Status of INT1_FTH see LSM6DS3_ACC_GYRO_INT1_FTH_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_FIFO_TSHLD_on_INT1(void *handle, LSM6DS3_ACC_GYRO_INT1_FTH_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_FIFO_TSHLD_on_INT1(void *handle, LSM6DS3_ACC_GYRO_INT1_FTH_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_INT1_CTRL, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -1653,7 +1653,7 @@ status_t LSM6DS3_ACC_GYRO_R_FIFO_TSHLD_on_INT1(void *handle, LSM6DS3_ACC_GYRO_IN
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM6DS3_ACC_GYRO_W_OVERRUN_on_INT1(void *handle, LSM6DS3_ACC_GYRO_INT1_OVR_t newValue)
+mems_status_t  LSM6DS3_ACC_GYRO_W_OVERRUN_on_INT1(void *handle, LSM6DS3_ACC_GYRO_INT1_OVR_t newValue)
 {
   u8_t value;
 
@@ -1676,7 +1676,7 @@ status_t  LSM6DS3_ACC_GYRO_W_OVERRUN_on_INT1(void *handle, LSM6DS3_ACC_GYRO_INT1
 * Output         : Status of INT1_OVR see LSM6DS3_ACC_GYRO_INT1_OVR_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_OVERRUN_on_INT1(void *handle, LSM6DS3_ACC_GYRO_INT1_OVR_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_OVERRUN_on_INT1(void *handle, LSM6DS3_ACC_GYRO_INT1_OVR_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_INT1_CTRL, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -1693,7 +1693,7 @@ status_t LSM6DS3_ACC_GYRO_R_OVERRUN_on_INT1(void *handle, LSM6DS3_ACC_GYRO_INT1_
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM6DS3_ACC_GYRO_W_FSS5_on_INT1(void *handle, LSM6DS3_ACC_GYRO_INT1_FSS5_t newValue)
+mems_status_t  LSM6DS3_ACC_GYRO_W_FSS5_on_INT1(void *handle, LSM6DS3_ACC_GYRO_INT1_FSS5_t newValue)
 {
   u8_t value;
 
@@ -1716,7 +1716,7 @@ status_t  LSM6DS3_ACC_GYRO_W_FSS5_on_INT1(void *handle, LSM6DS3_ACC_GYRO_INT1_FS
 * Output         : Status of INT1_FSS5 see LSM6DS3_ACC_GYRO_INT1_FSS5_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_FSS5_on_INT1(void *handle, LSM6DS3_ACC_GYRO_INT1_FSS5_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_FSS5_on_INT1(void *handle, LSM6DS3_ACC_GYRO_INT1_FSS5_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_INT1_CTRL, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -1733,7 +1733,7 @@ status_t LSM6DS3_ACC_GYRO_R_FSS5_on_INT1(void *handle, LSM6DS3_ACC_GYRO_INT1_FSS
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM6DS3_ACC_GYRO_W_SIGN_MOT_on_INT1(void *handle, LSM6DS3_ACC_GYRO_INT1_SIGN_MOT_t newValue)
+mems_status_t  LSM6DS3_ACC_GYRO_W_SIGN_MOT_on_INT1(void *handle, LSM6DS3_ACC_GYRO_INT1_SIGN_MOT_t newValue)
 {
   u8_t value;
 
@@ -1756,7 +1756,7 @@ status_t  LSM6DS3_ACC_GYRO_W_SIGN_MOT_on_INT1(void *handle, LSM6DS3_ACC_GYRO_INT
 * Output         : Status of INT1_SIGN_MOT see LSM6DS3_ACC_GYRO_INT1_SIGN_MOT_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_SIGN_MOT_on_INT1(void *handle, LSM6DS3_ACC_GYRO_INT1_SIGN_MOT_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_SIGN_MOT_on_INT1(void *handle, LSM6DS3_ACC_GYRO_INT1_SIGN_MOT_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_INT1_CTRL, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -1773,7 +1773,7 @@ status_t LSM6DS3_ACC_GYRO_R_SIGN_MOT_on_INT1(void *handle, LSM6DS3_ACC_GYRO_INT1
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM6DS3_ACC_GYRO_W_PEDO_STEP_on_INT1(void *handle, LSM6DS3_ACC_GYRO_INT1_PEDO_t newValue)
+mems_status_t  LSM6DS3_ACC_GYRO_W_PEDO_STEP_on_INT1(void *handle, LSM6DS3_ACC_GYRO_INT1_PEDO_t newValue)
 {
   u8_t value;
 
@@ -1796,7 +1796,7 @@ status_t  LSM6DS3_ACC_GYRO_W_PEDO_STEP_on_INT1(void *handle, LSM6DS3_ACC_GYRO_IN
 * Output         : Status of INT1_PEDO see LSM6DS3_ACC_GYRO_INT1_PEDO_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_PEDO_STEP_on_INT1(void *handle, LSM6DS3_ACC_GYRO_INT1_PEDO_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_PEDO_STEP_on_INT1(void *handle, LSM6DS3_ACC_GYRO_INT1_PEDO_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_INT1_CTRL, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -1813,7 +1813,7 @@ status_t LSM6DS3_ACC_GYRO_R_PEDO_STEP_on_INT1(void *handle, LSM6DS3_ACC_GYRO_INT
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM6DS3_ACC_GYRO_W_DRDY_XL_on_INT2(void *handle, LSM6DS3_ACC_GYRO_INT2_DRDY_XL_t newValue)
+mems_status_t  LSM6DS3_ACC_GYRO_W_DRDY_XL_on_INT2(void *handle, LSM6DS3_ACC_GYRO_INT2_DRDY_XL_t newValue)
 {
   u8_t value;
 
@@ -1836,7 +1836,7 @@ status_t  LSM6DS3_ACC_GYRO_W_DRDY_XL_on_INT2(void *handle, LSM6DS3_ACC_GYRO_INT2
 * Output         : Status of INT2_DRDY_XL see LSM6DS3_ACC_GYRO_INT2_DRDY_XL_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_DRDY_XL_on_INT2(void *handle, LSM6DS3_ACC_GYRO_INT2_DRDY_XL_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_DRDY_XL_on_INT2(void *handle, LSM6DS3_ACC_GYRO_INT2_DRDY_XL_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_INT2_CTRL, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -1853,7 +1853,7 @@ status_t LSM6DS3_ACC_GYRO_R_DRDY_XL_on_INT2(void *handle, LSM6DS3_ACC_GYRO_INT2_
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM6DS3_ACC_GYRO_W_DRDY_G_on_INT2(void *handle, LSM6DS3_ACC_GYRO_INT2_DRDY_G_t newValue)
+mems_status_t  LSM6DS3_ACC_GYRO_W_DRDY_G_on_INT2(void *handle, LSM6DS3_ACC_GYRO_INT2_DRDY_G_t newValue)
 {
   u8_t value;
 
@@ -1876,7 +1876,7 @@ status_t  LSM6DS3_ACC_GYRO_W_DRDY_G_on_INT2(void *handle, LSM6DS3_ACC_GYRO_INT2_
 * Output         : Status of INT2_DRDY_G see LSM6DS3_ACC_GYRO_INT2_DRDY_G_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_DRDY_G_on_INT2(void *handle, LSM6DS3_ACC_GYRO_INT2_DRDY_G_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_DRDY_G_on_INT2(void *handle, LSM6DS3_ACC_GYRO_INT2_DRDY_G_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_INT2_CTRL, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -1893,7 +1893,7 @@ status_t LSM6DS3_ACC_GYRO_R_DRDY_G_on_INT2(void *handle, LSM6DS3_ACC_GYRO_INT2_D
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM6DS3_ACC_GYRO_W_DRDY_TEMP_on_INT2(void *handle, LSM6DS3_ACC_GYRO_INT2_DRDY_TEMP_t newValue)
+mems_status_t  LSM6DS3_ACC_GYRO_W_DRDY_TEMP_on_INT2(void *handle, LSM6DS3_ACC_GYRO_INT2_DRDY_TEMP_t newValue)
 {
   u8_t value;
 
@@ -1916,7 +1916,7 @@ status_t  LSM6DS3_ACC_GYRO_W_DRDY_TEMP_on_INT2(void *handle, LSM6DS3_ACC_GYRO_IN
 * Output         : Status of INT2_DRDY_TEMP see LSM6DS3_ACC_GYRO_INT2_DRDY_TEMP_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_DRDY_TEMP_on_INT2(void *handle, LSM6DS3_ACC_GYRO_INT2_DRDY_TEMP_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_DRDY_TEMP_on_INT2(void *handle, LSM6DS3_ACC_GYRO_INT2_DRDY_TEMP_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_INT2_CTRL, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -1933,7 +1933,7 @@ status_t LSM6DS3_ACC_GYRO_R_DRDY_TEMP_on_INT2(void *handle, LSM6DS3_ACC_GYRO_INT
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM6DS3_ACC_GYRO_W_FIFO_TSHLD_on_INT2(void *handle, LSM6DS3_ACC_GYRO_INT2_FTH_t newValue)
+mems_status_t  LSM6DS3_ACC_GYRO_W_FIFO_TSHLD_on_INT2(void *handle, LSM6DS3_ACC_GYRO_INT2_FTH_t newValue)
 {
   u8_t value;
 
@@ -1956,7 +1956,7 @@ status_t  LSM6DS3_ACC_GYRO_W_FIFO_TSHLD_on_INT2(void *handle, LSM6DS3_ACC_GYRO_I
 * Output         : Status of INT2_FTH see LSM6DS3_ACC_GYRO_INT2_FTH_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_FIFO_TSHLD_on_INT2(void *handle, LSM6DS3_ACC_GYRO_INT2_FTH_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_FIFO_TSHLD_on_INT2(void *handle, LSM6DS3_ACC_GYRO_INT2_FTH_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_INT2_CTRL, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -1973,7 +1973,7 @@ status_t LSM6DS3_ACC_GYRO_R_FIFO_TSHLD_on_INT2(void *handle, LSM6DS3_ACC_GYRO_IN
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM6DS3_ACC_GYRO_W_OVERRUN_on_INT2(void *handle, LSM6DS3_ACC_GYRO_INT2_OVR_t newValue)
+mems_status_t  LSM6DS3_ACC_GYRO_W_OVERRUN_on_INT2(void *handle, LSM6DS3_ACC_GYRO_INT2_OVR_t newValue)
 {
   u8_t value;
 
@@ -1996,7 +1996,7 @@ status_t  LSM6DS3_ACC_GYRO_W_OVERRUN_on_INT2(void *handle, LSM6DS3_ACC_GYRO_INT2
 * Output         : Status of INT2_OVR see LSM6DS3_ACC_GYRO_INT2_OVR_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_OVERRUN_on_INT2(void *handle, LSM6DS3_ACC_GYRO_INT2_OVR_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_OVERRUN_on_INT2(void *handle, LSM6DS3_ACC_GYRO_INT2_OVR_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_INT2_CTRL, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -2013,7 +2013,7 @@ status_t LSM6DS3_ACC_GYRO_R_OVERRUN_on_INT2(void *handle, LSM6DS3_ACC_GYRO_INT2_
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM6DS3_ACC_GYRO_W_FSS5_on_INT2(void *handle, LSM6DS3_ACC_GYRO_INT2_FSS5_t newValue)
+mems_status_t  LSM6DS3_ACC_GYRO_W_FSS5_on_INT2(void *handle, LSM6DS3_ACC_GYRO_INT2_FSS5_t newValue)
 {
   u8_t value;
 
@@ -2036,7 +2036,7 @@ status_t  LSM6DS3_ACC_GYRO_W_FSS5_on_INT2(void *handle, LSM6DS3_ACC_GYRO_INT2_FS
 * Output         : Status of INT2_FSS5 see LSM6DS3_ACC_GYRO_INT2_FSS5_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_FSS5_on_INT2(void *handle, LSM6DS3_ACC_GYRO_INT2_FSS5_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_FSS5_on_INT2(void *handle, LSM6DS3_ACC_GYRO_INT2_FSS5_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_INT2_CTRL, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -2053,7 +2053,7 @@ status_t LSM6DS3_ACC_GYRO_R_FSS5_on_INT2(void *handle, LSM6DS3_ACC_GYRO_INT2_FSS
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM6DS3_ACC_GYRO_W_SIGN_MOT_on_INT2(void *handle, LSM6DS3_ACC_GYRO_INT2_SIGN_MOT_t newValue)
+mems_status_t  LSM6DS3_ACC_GYRO_W_SIGN_MOT_on_INT2(void *handle, LSM6DS3_ACC_GYRO_INT2_SIGN_MOT_t newValue)
 {
   u8_t value;
 
@@ -2076,7 +2076,7 @@ status_t  LSM6DS3_ACC_GYRO_W_SIGN_MOT_on_INT2(void *handle, LSM6DS3_ACC_GYRO_INT
 * Output         : Status of INT2_SIGN_MOT see LSM6DS3_ACC_GYRO_INT2_SIGN_MOT_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_SIGN_MOT_on_INT2(void *handle, LSM6DS3_ACC_GYRO_INT2_SIGN_MOT_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_SIGN_MOT_on_INT2(void *handle, LSM6DS3_ACC_GYRO_INT2_SIGN_MOT_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_INT2_CTRL, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -2093,7 +2093,7 @@ status_t LSM6DS3_ACC_GYRO_R_SIGN_MOT_on_INT2(void *handle, LSM6DS3_ACC_GYRO_INT2
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM6DS3_ACC_GYRO_W_PEDO_STEP_on_INT2(void *handle, LSM6DS3_ACC_GYRO_INT2_PEDO_t newValue)
+mems_status_t  LSM6DS3_ACC_GYRO_W_PEDO_STEP_on_INT2(void *handle, LSM6DS3_ACC_GYRO_INT2_PEDO_t newValue)
 {
   u8_t value;
 
@@ -2116,7 +2116,7 @@ status_t  LSM6DS3_ACC_GYRO_W_PEDO_STEP_on_INT2(void *handle, LSM6DS3_ACC_GYRO_IN
 * Output         : Status of INT2_PEDO see LSM6DS3_ACC_GYRO_INT2_PEDO_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_PEDO_STEP_on_INT2(void *handle, LSM6DS3_ACC_GYRO_INT2_PEDO_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_PEDO_STEP_on_INT2(void *handle, LSM6DS3_ACC_GYRO_INT2_PEDO_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_INT2_CTRL, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -2133,7 +2133,7 @@ status_t LSM6DS3_ACC_GYRO_R_PEDO_STEP_on_INT2(void *handle, LSM6DS3_ACC_GYRO_INT
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM6DS3_ACC_GYRO_W_SW_RESET(void *handle, LSM6DS3_ACC_GYRO_SW_RESET_t newValue)
+mems_status_t  LSM6DS3_ACC_GYRO_W_SW_RESET(void *handle, LSM6DS3_ACC_GYRO_SW_RESET_t newValue)
 {
   u8_t value;
 
@@ -2156,7 +2156,7 @@ status_t  LSM6DS3_ACC_GYRO_W_SW_RESET(void *handle, LSM6DS3_ACC_GYRO_SW_RESET_t 
 * Output         : Status of SW_RESET see LSM6DS3_ACC_GYRO_SW_RESET_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_SW_RESET(void *handle, LSM6DS3_ACC_GYRO_SW_RESET_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_SW_RESET(void *handle, LSM6DS3_ACC_GYRO_SW_RESET_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_CTRL3_C, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -2173,7 +2173,7 @@ status_t LSM6DS3_ACC_GYRO_R_SW_RESET(void *handle, LSM6DS3_ACC_GYRO_SW_RESET_t *
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM6DS3_ACC_GYRO_W_BLE(void *handle, LSM6DS3_ACC_GYRO_BLE_t newValue)
+mems_status_t  LSM6DS3_ACC_GYRO_W_BLE(void *handle, LSM6DS3_ACC_GYRO_BLE_t newValue)
 {
   u8_t value;
 
@@ -2196,7 +2196,7 @@ status_t  LSM6DS3_ACC_GYRO_W_BLE(void *handle, LSM6DS3_ACC_GYRO_BLE_t newValue)
 * Output         : Status of BLE see LSM6DS3_ACC_GYRO_BLE_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_BLE(void *handle, LSM6DS3_ACC_GYRO_BLE_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_BLE(void *handle, LSM6DS3_ACC_GYRO_BLE_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_CTRL3_C, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -2213,7 +2213,7 @@ status_t LSM6DS3_ACC_GYRO_R_BLE(void *handle, LSM6DS3_ACC_GYRO_BLE_t *value)
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM6DS3_ACC_GYRO_W_IF_Addr_Incr(void *handle, LSM6DS3_ACC_GYRO_IF_INC_t newValue)
+mems_status_t  LSM6DS3_ACC_GYRO_W_IF_Addr_Incr(void *handle, LSM6DS3_ACC_GYRO_IF_INC_t newValue)
 {
   u8_t value;
 
@@ -2236,7 +2236,7 @@ status_t  LSM6DS3_ACC_GYRO_W_IF_Addr_Incr(void *handle, LSM6DS3_ACC_GYRO_IF_INC_
 * Output         : Status of IF_INC see LSM6DS3_ACC_GYRO_IF_INC_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_IF_Addr_Incr(void *handle, LSM6DS3_ACC_GYRO_IF_INC_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_IF_Addr_Incr(void *handle, LSM6DS3_ACC_GYRO_IF_INC_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_CTRL3_C, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -2253,7 +2253,7 @@ status_t LSM6DS3_ACC_GYRO_R_IF_Addr_Incr(void *handle, LSM6DS3_ACC_GYRO_IF_INC_t
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM6DS3_ACC_GYRO_W_SPI_Mode(void *handle, LSM6DS3_ACC_GYRO_SIM_t newValue)
+mems_status_t  LSM6DS3_ACC_GYRO_W_SPI_Mode(void *handle, LSM6DS3_ACC_GYRO_SIM_t newValue)
 {
   u8_t value;
 
@@ -2276,7 +2276,7 @@ status_t  LSM6DS3_ACC_GYRO_W_SPI_Mode(void *handle, LSM6DS3_ACC_GYRO_SIM_t newVa
 * Output         : Status of SIM see LSM6DS3_ACC_GYRO_SIM_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_SPI_Mode(void *handle, LSM6DS3_ACC_GYRO_SIM_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_SPI_Mode(void *handle, LSM6DS3_ACC_GYRO_SIM_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_CTRL3_C, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -2293,7 +2293,7 @@ status_t LSM6DS3_ACC_GYRO_R_SPI_Mode(void *handle, LSM6DS3_ACC_GYRO_SIM_t *value
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM6DS3_ACC_GYRO_W_PadSel(void *handle, LSM6DS3_ACC_GYRO_PP_OD_t newValue)
+mems_status_t  LSM6DS3_ACC_GYRO_W_PadSel(void *handle, LSM6DS3_ACC_GYRO_PP_OD_t newValue)
 {
   u8_t value;
 
@@ -2316,7 +2316,7 @@ status_t  LSM6DS3_ACC_GYRO_W_PadSel(void *handle, LSM6DS3_ACC_GYRO_PP_OD_t newVa
 * Output         : Status of PP_OD see LSM6DS3_ACC_GYRO_PP_OD_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_PadSel(void *handle, LSM6DS3_ACC_GYRO_PP_OD_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_PadSel(void *handle, LSM6DS3_ACC_GYRO_PP_OD_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_CTRL3_C, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -2333,7 +2333,7 @@ status_t LSM6DS3_ACC_GYRO_R_PadSel(void *handle, LSM6DS3_ACC_GYRO_PP_OD_t *value
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM6DS3_ACC_GYRO_W_INT_ACT_LEVEL(void *handle, LSM6DS3_ACC_GYRO_INT_ACT_LEVEL_t newValue)
+mems_status_t  LSM6DS3_ACC_GYRO_W_INT_ACT_LEVEL(void *handle, LSM6DS3_ACC_GYRO_INT_ACT_LEVEL_t newValue)
 {
   u8_t value;
 
@@ -2356,7 +2356,7 @@ status_t  LSM6DS3_ACC_GYRO_W_INT_ACT_LEVEL(void *handle, LSM6DS3_ACC_GYRO_INT_AC
 * Output         : Status of INT_ACT_LEVEL see LSM6DS3_ACC_GYRO_INT_ACT_LEVEL_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_INT_ACT_LEVEL(void *handle, LSM6DS3_ACC_GYRO_INT_ACT_LEVEL_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_INT_ACT_LEVEL(void *handle, LSM6DS3_ACC_GYRO_INT_ACT_LEVEL_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_CTRL3_C, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -2373,7 +2373,7 @@ status_t LSM6DS3_ACC_GYRO_R_INT_ACT_LEVEL(void *handle, LSM6DS3_ACC_GYRO_INT_ACT
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM6DS3_ACC_GYRO_W_BOOT(void *handle, LSM6DS3_ACC_GYRO_BOOT_t newValue)
+mems_status_t  LSM6DS3_ACC_GYRO_W_BOOT(void *handle, LSM6DS3_ACC_GYRO_BOOT_t newValue)
 {
   u8_t value;
 
@@ -2396,7 +2396,7 @@ status_t  LSM6DS3_ACC_GYRO_W_BOOT(void *handle, LSM6DS3_ACC_GYRO_BOOT_t newValue
 * Output         : Status of BOOT see LSM6DS3_ACC_GYRO_BOOT_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_BOOT(void *handle, LSM6DS3_ACC_GYRO_BOOT_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_BOOT(void *handle, LSM6DS3_ACC_GYRO_BOOT_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_CTRL3_C, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -2413,7 +2413,7 @@ status_t LSM6DS3_ACC_GYRO_R_BOOT(void *handle, LSM6DS3_ACC_GYRO_BOOT_t *value)
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM6DS3_ACC_GYRO_W_STOP_ON_FTH(void *handle, LSM6DS3_ACC_GYRO_STOP_ON_FTH_t newValue)
+mems_status_t  LSM6DS3_ACC_GYRO_W_STOP_ON_FTH(void *handle, LSM6DS3_ACC_GYRO_STOP_ON_FTH_t newValue)
 {
   u8_t value;
 
@@ -2436,7 +2436,7 @@ status_t  LSM6DS3_ACC_GYRO_W_STOP_ON_FTH(void *handle, LSM6DS3_ACC_GYRO_STOP_ON_
 * Output         : Status of STOP_ON_FTH see LSM6DS3_ACC_GYRO_STOP_ON_FTH_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_STOP_ON_FTH(void *handle, LSM6DS3_ACC_GYRO_STOP_ON_FTH_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_STOP_ON_FTH(void *handle, LSM6DS3_ACC_GYRO_STOP_ON_FTH_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_CTRL4_C, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -2453,7 +2453,7 @@ status_t LSM6DS3_ACC_GYRO_R_STOP_ON_FTH(void *handle, LSM6DS3_ACC_GYRO_STOP_ON_F
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM6DS3_ACC_GYRO_W_MODE3_Enable(void *handle, LSM6DS3_ACC_GYRO_MODE3_EN_t newValue)
+mems_status_t  LSM6DS3_ACC_GYRO_W_MODE3_Enable(void *handle, LSM6DS3_ACC_GYRO_MODE3_EN_t newValue)
 {
   u8_t value;
 
@@ -2476,7 +2476,7 @@ status_t  LSM6DS3_ACC_GYRO_W_MODE3_Enable(void *handle, LSM6DS3_ACC_GYRO_MODE3_E
 * Output         : Status of MODE3_EN see LSM6DS3_ACC_GYRO_MODE3_EN_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_MODE3_Enable(void *handle, LSM6DS3_ACC_GYRO_MODE3_EN_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_MODE3_Enable(void *handle, LSM6DS3_ACC_GYRO_MODE3_EN_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_CTRL4_C, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -2493,7 +2493,7 @@ status_t LSM6DS3_ACC_GYRO_R_MODE3_Enable(void *handle, LSM6DS3_ACC_GYRO_MODE3_EN
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM6DS3_ACC_GYRO_W_I2C_DISABLE(void *handle, LSM6DS3_ACC_GYRO_I2C_DISABLE_t newValue)
+mems_status_t  LSM6DS3_ACC_GYRO_W_I2C_DISABLE(void *handle, LSM6DS3_ACC_GYRO_I2C_DISABLE_t newValue)
 {
   u8_t value;
 
@@ -2516,7 +2516,7 @@ status_t  LSM6DS3_ACC_GYRO_W_I2C_DISABLE(void *handle, LSM6DS3_ACC_GYRO_I2C_DISA
 * Output         : Status of I2C_DISABLE see LSM6DS3_ACC_GYRO_I2C_DISABLE_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_I2C_DISABLE(void *handle, LSM6DS3_ACC_GYRO_I2C_DISABLE_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_I2C_DISABLE(void *handle, LSM6DS3_ACC_GYRO_I2C_DISABLE_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_CTRL4_C, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -2533,7 +2533,7 @@ status_t LSM6DS3_ACC_GYRO_R_I2C_DISABLE(void *handle, LSM6DS3_ACC_GYRO_I2C_DISAB
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM6DS3_ACC_GYRO_W_DRDY_MSK(void *handle, LSM6DS3_ACC_GYRO_DRDY_MSK_t newValue)
+mems_status_t  LSM6DS3_ACC_GYRO_W_DRDY_MSK(void *handle, LSM6DS3_ACC_GYRO_DRDY_MSK_t newValue)
 {
   u8_t value;
 
@@ -2556,7 +2556,7 @@ status_t  LSM6DS3_ACC_GYRO_W_DRDY_MSK(void *handle, LSM6DS3_ACC_GYRO_DRDY_MSK_t 
 * Output         : Status of DRDY_MSK see LSM6DS3_ACC_GYRO_DRDY_MSK_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_DRDY_MSK(void *handle, LSM6DS3_ACC_GYRO_DRDY_MSK_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_DRDY_MSK(void *handle, LSM6DS3_ACC_GYRO_DRDY_MSK_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_CTRL4_C, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -2573,7 +2573,7 @@ status_t LSM6DS3_ACC_GYRO_R_DRDY_MSK(void *handle, LSM6DS3_ACC_GYRO_DRDY_MSK_t *
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM6DS3_ACC_GYRO_W_FIFO_TEMP_EN(void *handle, LSM6DS3_ACC_GYRO_FIFO_TEMP_EN_t newValue)
+mems_status_t  LSM6DS3_ACC_GYRO_W_FIFO_TEMP_EN(void *handle, LSM6DS3_ACC_GYRO_FIFO_TEMP_EN_t newValue)
 {
   u8_t value;
 
@@ -2596,7 +2596,7 @@ status_t  LSM6DS3_ACC_GYRO_W_FIFO_TEMP_EN(void *handle, LSM6DS3_ACC_GYRO_FIFO_TE
 * Output         : Status of FIFO_TEMP_EN see LSM6DS3_ACC_GYRO_FIFO_TEMP_EN_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_FIFO_TEMP_EN(void *handle, LSM6DS3_ACC_GYRO_FIFO_TEMP_EN_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_FIFO_TEMP_EN(void *handle, LSM6DS3_ACC_GYRO_FIFO_TEMP_EN_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_CTRL4_C, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -2613,7 +2613,7 @@ status_t LSM6DS3_ACC_GYRO_R_FIFO_TEMP_EN(void *handle, LSM6DS3_ACC_GYRO_FIFO_TEM
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM6DS3_ACC_GYRO_W_INT2_ON_INT1(void *handle, LSM6DS3_ACC_GYRO_INT2_ON_INT1_t newValue)
+mems_status_t  LSM6DS3_ACC_GYRO_W_INT2_ON_INT1(void *handle, LSM6DS3_ACC_GYRO_INT2_ON_INT1_t newValue)
 {
   u8_t value;
 
@@ -2636,7 +2636,7 @@ status_t  LSM6DS3_ACC_GYRO_W_INT2_ON_INT1(void *handle, LSM6DS3_ACC_GYRO_INT2_ON
 * Output         : Status of INT2_ON_INT1 see LSM6DS3_ACC_GYRO_INT2_ON_INT1_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_INT2_ON_INT1(void *handle, LSM6DS3_ACC_GYRO_INT2_ON_INT1_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_INT2_ON_INT1(void *handle, LSM6DS3_ACC_GYRO_INT2_ON_INT1_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_CTRL4_C, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -2653,7 +2653,7 @@ status_t LSM6DS3_ACC_GYRO_R_INT2_ON_INT1(void *handle, LSM6DS3_ACC_GYRO_INT2_ON_
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM6DS3_ACC_GYRO_W_SleepMode_G(void *handle, LSM6DS3_ACC_GYRO_SLEEP_G_t newValue)
+mems_status_t  LSM6DS3_ACC_GYRO_W_SleepMode_G(void *handle, LSM6DS3_ACC_GYRO_SLEEP_G_t newValue)
 {
   u8_t value;
 
@@ -2676,7 +2676,7 @@ status_t  LSM6DS3_ACC_GYRO_W_SleepMode_G(void *handle, LSM6DS3_ACC_GYRO_SLEEP_G_
 * Output         : Status of SLEEP_G see LSM6DS3_ACC_GYRO_SLEEP_G_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_SleepMode_G(void *handle, LSM6DS3_ACC_GYRO_SLEEP_G_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_SleepMode_G(void *handle, LSM6DS3_ACC_GYRO_SLEEP_G_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_CTRL4_C, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -2693,7 +2693,7 @@ status_t LSM6DS3_ACC_GYRO_R_SleepMode_G(void *handle, LSM6DS3_ACC_GYRO_SLEEP_G_t
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM6DS3_ACC_GYRO_W_BW_Fixed_By_ODR(void *handle, LSM6DS3_ACC_GYRO_BW_SCAL_ODR_t newValue)
+mems_status_t  LSM6DS3_ACC_GYRO_W_BW_Fixed_By_ODR(void *handle, LSM6DS3_ACC_GYRO_BW_SCAL_ODR_t newValue)
 {
   u8_t value;
 
@@ -2716,7 +2716,7 @@ status_t  LSM6DS3_ACC_GYRO_W_BW_Fixed_By_ODR(void *handle, LSM6DS3_ACC_GYRO_BW_S
 * Output         : Status of BW_SCAL_ODR see LSM6DS3_ACC_GYRO_BW_SCAL_ODR_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_BW_Fixed_By_ODR(void *handle, LSM6DS3_ACC_GYRO_BW_SCAL_ODR_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_BW_Fixed_By_ODR(void *handle, LSM6DS3_ACC_GYRO_BW_SCAL_ODR_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_CTRL4_C, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -2733,7 +2733,7 @@ status_t LSM6DS3_ACC_GYRO_R_BW_Fixed_By_ODR(void *handle, LSM6DS3_ACC_GYRO_BW_SC
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM6DS3_ACC_GYRO_W_SelfTest_XL(void *handle, LSM6DS3_ACC_GYRO_ST_XL_t newValue)
+mems_status_t  LSM6DS3_ACC_GYRO_W_SelfTest_XL(void *handle, LSM6DS3_ACC_GYRO_ST_XL_t newValue)
 {
   u8_t value;
 
@@ -2756,7 +2756,7 @@ status_t  LSM6DS3_ACC_GYRO_W_SelfTest_XL(void *handle, LSM6DS3_ACC_GYRO_ST_XL_t 
 * Output         : Status of ST_XL see LSM6DS3_ACC_GYRO_ST_XL_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_SelfTest_XL(void *handle, LSM6DS3_ACC_GYRO_ST_XL_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_SelfTest_XL(void *handle, LSM6DS3_ACC_GYRO_ST_XL_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_CTRL5_C, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -2773,7 +2773,7 @@ status_t LSM6DS3_ACC_GYRO_R_SelfTest_XL(void *handle, LSM6DS3_ACC_GYRO_ST_XL_t *
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM6DS3_ACC_GYRO_W_SelfTest_G(void *handle, LSM6DS3_ACC_GYRO_ST_G_t newValue)
+mems_status_t  LSM6DS3_ACC_GYRO_W_SelfTest_G(void *handle, LSM6DS3_ACC_GYRO_ST_G_t newValue)
 {
   u8_t value;
 
@@ -2796,7 +2796,7 @@ status_t  LSM6DS3_ACC_GYRO_W_SelfTest_G(void *handle, LSM6DS3_ACC_GYRO_ST_G_t ne
 * Output         : Status of ST_G see LSM6DS3_ACC_GYRO_ST_G_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_SelfTest_G(void *handle, LSM6DS3_ACC_GYRO_ST_G_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_SelfTest_G(void *handle, LSM6DS3_ACC_GYRO_ST_G_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_CTRL5_C, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -2813,7 +2813,7 @@ status_t LSM6DS3_ACC_GYRO_R_SelfTest_G(void *handle, LSM6DS3_ACC_GYRO_ST_G_t *va
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM6DS3_ACC_GYRO_W_CircularBurstMode(void *handle, LSM6DS3_ACC_GYRO_ROUNDING_t newValue)
+mems_status_t  LSM6DS3_ACC_GYRO_W_CircularBurstMode(void *handle, LSM6DS3_ACC_GYRO_ROUNDING_t newValue)
 {
   u8_t value;
 
@@ -2837,7 +2837,7 @@ status_t  LSM6DS3_ACC_GYRO_W_CircularBurstMode(void *handle, LSM6DS3_ACC_GYRO_RO
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
 
-status_t LSM6DS3_ACC_GYRO_R_CircularBurstMode(void *handle, LSM6DS3_ACC_GYRO_ROUNDING_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_CircularBurstMode(void *handle, LSM6DS3_ACC_GYRO_ROUNDING_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_CTRL5_C, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -2854,7 +2854,7 @@ status_t LSM6DS3_ACC_GYRO_R_CircularBurstMode(void *handle, LSM6DS3_ACC_GYRO_ROU
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM6DS3_ACC_GYRO_W_LowPower_XL(void *handle, LSM6DS3_ACC_GYRO_LP_XL_t newValue)
+mems_status_t  LSM6DS3_ACC_GYRO_W_LowPower_XL(void *handle, LSM6DS3_ACC_GYRO_LP_XL_t newValue)
 {
   u8_t value;
 
@@ -2877,7 +2877,7 @@ status_t  LSM6DS3_ACC_GYRO_W_LowPower_XL(void *handle, LSM6DS3_ACC_GYRO_LP_XL_t 
 * Output         : Status of LP_XL see LSM6DS3_ACC_GYRO_LP_XL_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_LowPower_XL(void *handle, LSM6DS3_ACC_GYRO_LP_XL_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_LowPower_XL(void *handle, LSM6DS3_ACC_GYRO_LP_XL_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_CTRL6_G, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -2894,7 +2894,7 @@ status_t LSM6DS3_ACC_GYRO_R_LowPower_XL(void *handle, LSM6DS3_ACC_GYRO_LP_XL_t *
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM6DS3_ACC_GYRO_W_DEN_LVL2_EN(void *handle, LSM6DS3_ACC_GYRO_DEN_LVL2_EN_t newValue)
+mems_status_t  LSM6DS3_ACC_GYRO_W_DEN_LVL2_EN(void *handle, LSM6DS3_ACC_GYRO_DEN_LVL2_EN_t newValue)
 {
   u8_t value;
 
@@ -2917,7 +2917,7 @@ status_t  LSM6DS3_ACC_GYRO_W_DEN_LVL2_EN(void *handle, LSM6DS3_ACC_GYRO_DEN_LVL2
 * Output         : Status of DEN_LVL2_EN see LSM6DS3_ACC_GYRO_DEN_LVL2_EN_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_DEN_LVL2_EN(void *handle, LSM6DS3_ACC_GYRO_DEN_LVL2_EN_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_DEN_LVL2_EN(void *handle, LSM6DS3_ACC_GYRO_DEN_LVL2_EN_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_CTRL6_G, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -2934,7 +2934,7 @@ status_t LSM6DS3_ACC_GYRO_R_DEN_LVL2_EN(void *handle, LSM6DS3_ACC_GYRO_DEN_LVL2_
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM6DS3_ACC_GYRO_W_DEN_LVL_EN(void *handle, LSM6DS3_ACC_GYRO_DEN_LVL_EN_t newValue)
+mems_status_t  LSM6DS3_ACC_GYRO_W_DEN_LVL_EN(void *handle, LSM6DS3_ACC_GYRO_DEN_LVL_EN_t newValue)
 {
   u8_t value;
 
@@ -2957,7 +2957,7 @@ status_t  LSM6DS3_ACC_GYRO_W_DEN_LVL_EN(void *handle, LSM6DS3_ACC_GYRO_DEN_LVL_E
 * Output         : Status of DEN_LVL_EN see LSM6DS3_ACC_GYRO_DEN_LVL_EN_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_DEN_LVL_EN(void *handle, LSM6DS3_ACC_GYRO_DEN_LVL_EN_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_DEN_LVL_EN(void *handle, LSM6DS3_ACC_GYRO_DEN_LVL_EN_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_CTRL6_G, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -2974,7 +2974,7 @@ status_t LSM6DS3_ACC_GYRO_R_DEN_LVL_EN(void *handle, LSM6DS3_ACC_GYRO_DEN_LVL_EN
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM6DS3_ACC_GYRO_W_DEN_EDGE_EN(void *handle, LSM6DS3_ACC_GYRO_DEN_EDGE_EN_t newValue)
+mems_status_t  LSM6DS3_ACC_GYRO_W_DEN_EDGE_EN(void *handle, LSM6DS3_ACC_GYRO_DEN_EDGE_EN_t newValue)
 {
   u8_t value;
 
@@ -2997,7 +2997,7 @@ status_t  LSM6DS3_ACC_GYRO_W_DEN_EDGE_EN(void *handle, LSM6DS3_ACC_GYRO_DEN_EDGE
 * Output         : Status of DEN_EDGE_EN see LSM6DS3_ACC_GYRO_DEN_EDGE_EN_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_DEN_EDGE_EN(void *handle, LSM6DS3_ACC_GYRO_DEN_EDGE_EN_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_DEN_EDGE_EN(void *handle, LSM6DS3_ACC_GYRO_DEN_EDGE_EN_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_CTRL6_G, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -3014,7 +3014,7 @@ status_t LSM6DS3_ACC_GYRO_R_DEN_EDGE_EN(void *handle, LSM6DS3_ACC_GYRO_DEN_EDGE_
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM6DS3_ACC_GYRO_W_HPCF_G(void *handle, LSM6DS3_ACC_GYRO_HPCF_G_t newValue)
+mems_status_t  LSM6DS3_ACC_GYRO_W_HPCF_G(void *handle, LSM6DS3_ACC_GYRO_HPCF_G_t newValue)
 {
   u8_t value;
 
@@ -3037,7 +3037,7 @@ status_t  LSM6DS3_ACC_GYRO_W_HPCF_G(void *handle, LSM6DS3_ACC_GYRO_HPCF_G_t newV
 * Output         : Status of HPCF_G see LSM6DS3_ACC_GYRO_HPCF_G_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_HPCF_G(void *handle, LSM6DS3_ACC_GYRO_HPCF_G_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_HPCF_G(void *handle, LSM6DS3_ACC_GYRO_HPCF_G_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_CTRL7_G, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -3054,7 +3054,7 @@ status_t LSM6DS3_ACC_GYRO_R_HPCF_G(void *handle, LSM6DS3_ACC_GYRO_HPCF_G_t *valu
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM6DS3_ACC_GYRO_W_HPFilter_En(void *handle, LSM6DS3_ACC_GYRO_HP_EN_t newValue)
+mems_status_t  LSM6DS3_ACC_GYRO_W_HPFilter_En(void *handle, LSM6DS3_ACC_GYRO_HP_EN_t newValue)
 {
   u8_t value;
 
@@ -3077,7 +3077,7 @@ status_t  LSM6DS3_ACC_GYRO_W_HPFilter_En(void *handle, LSM6DS3_ACC_GYRO_HP_EN_t 
 * Output         : Status of HP_EN see LSM6DS3_ACC_GYRO_HP_EN_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_HPFilter_En(void *handle, LSM6DS3_ACC_GYRO_HP_EN_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_HPFilter_En(void *handle, LSM6DS3_ACC_GYRO_HP_EN_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_CTRL7_G, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -3094,7 +3094,7 @@ status_t LSM6DS3_ACC_GYRO_R_HPFilter_En(void *handle, LSM6DS3_ACC_GYRO_HP_EN_t *
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM6DS3_ACC_GYRO_W_LP_Mode(void *handle, LSM6DS3_ACC_GYRO_LP_EN_t newValue)
+mems_status_t  LSM6DS3_ACC_GYRO_W_LP_Mode(void *handle, LSM6DS3_ACC_GYRO_LP_EN_t newValue)
 {
   u8_t value;
 
@@ -3117,7 +3117,7 @@ status_t  LSM6DS3_ACC_GYRO_W_LP_Mode(void *handle, LSM6DS3_ACC_GYRO_LP_EN_t newV
 * Output         : Status of LP_EN see LSM6DS3_ACC_GYRO_LP_EN_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_LP_Mode(void *handle, LSM6DS3_ACC_GYRO_LP_EN_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_LP_Mode(void *handle, LSM6DS3_ACC_GYRO_LP_EN_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_CTRL7_G, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -3134,7 +3134,7 @@ status_t LSM6DS3_ACC_GYRO_R_LP_Mode(void *handle, LSM6DS3_ACC_GYRO_LP_EN_t *valu
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM6DS3_ACC_GYRO_W_ROUNDING_STATUS(void *handle, LSM6DS3_ACC_GYRO_ROUNDING_STATUS_t newValue)
+mems_status_t  LSM6DS3_ACC_GYRO_W_ROUNDING_STATUS(void *handle, LSM6DS3_ACC_GYRO_ROUNDING_STATUS_t newValue)
 {
   u8_t value;
 
@@ -3157,7 +3157,7 @@ status_t  LSM6DS3_ACC_GYRO_W_ROUNDING_STATUS(void *handle, LSM6DS3_ACC_GYRO_ROUN
 * Output         : Status of ROUNDING_STATUS see LSM6DS3_ACC_GYRO_ROUNDING_STATUS_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_ROUNDING_STATUS(void *handle, LSM6DS3_ACC_GYRO_ROUNDING_STATUS_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_ROUNDING_STATUS(void *handle, LSM6DS3_ACC_GYRO_ROUNDING_STATUS_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_CTRL7_G, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -3174,7 +3174,7 @@ status_t LSM6DS3_ACC_GYRO_R_ROUNDING_STATUS(void *handle, LSM6DS3_ACC_GYRO_ROUND
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM6DS3_ACC_GYRO_W_HP_G_RST(void *handle, LSM6DS3_ACC_GYRO_HP_G_RST_t newValue)
+mems_status_t  LSM6DS3_ACC_GYRO_W_HP_G_RST(void *handle, LSM6DS3_ACC_GYRO_HP_G_RST_t newValue)
 {
   u8_t value;
 
@@ -3197,7 +3197,7 @@ status_t  LSM6DS3_ACC_GYRO_W_HP_G_RST(void *handle, LSM6DS3_ACC_GYRO_HP_G_RST_t 
 * Output         : Status of HP_G_RST see LSM6DS3_ACC_GYRO_HP_G_RST_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_HP_G_RST(void *handle, LSM6DS3_ACC_GYRO_HP_G_RST_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_HP_G_RST(void *handle, LSM6DS3_ACC_GYRO_HP_G_RST_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_CTRL7_G, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -3214,7 +3214,7 @@ status_t LSM6DS3_ACC_GYRO_R_HP_G_RST(void *handle, LSM6DS3_ACC_GYRO_HP_G_RST_t *
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM6DS3_ACC_GYRO_W_LPF2_XL(void *handle, LSM6DS3_ACC_GYRO_LPF2_XL_t newValue)
+mems_status_t  LSM6DS3_ACC_GYRO_W_LPF2_XL(void *handle, LSM6DS3_ACC_GYRO_LPF2_XL_t newValue)
 {
   u8_t value;
 
@@ -3237,7 +3237,7 @@ status_t  LSM6DS3_ACC_GYRO_W_LPF2_XL(void *handle, LSM6DS3_ACC_GYRO_LPF2_XL_t ne
 * Output         : Status of LPF2_XL_EN see LSM6DS3_ACC_GYRO_LPF2_XL_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_LPF2_XL(void *handle, LSM6DS3_ACC_GYRO_LPF2_XL_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_LPF2_XL(void *handle, LSM6DS3_ACC_GYRO_LPF2_XL_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_CTRL8_XL, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -3254,7 +3254,7 @@ status_t LSM6DS3_ACC_GYRO_R_LPF2_XL(void *handle, LSM6DS3_ACC_GYRO_LPF2_XL_t *va
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM6DS3_ACC_GYRO_W_HPCF_XL(void *handle, LSM6DS3_ACC_GYRO_HPCF_XL_t newValue)
+mems_status_t  LSM6DS3_ACC_GYRO_W_HPCF_XL(void *handle, LSM6DS3_ACC_GYRO_HPCF_XL_t newValue)
 {
   u8_t value;
 
@@ -3277,7 +3277,7 @@ status_t  LSM6DS3_ACC_GYRO_W_HPCF_XL(void *handle, LSM6DS3_ACC_GYRO_HPCF_XL_t ne
 * Output         : Status of HPCF_XL see LSM6DS3_ACC_GYRO_HPCF_XL_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_HPCF_XL(void *handle, LSM6DS3_ACC_GYRO_HPCF_XL_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_HPCF_XL(void *handle, LSM6DS3_ACC_GYRO_HPCF_XL_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_CTRL8_XL, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -3294,7 +3294,7 @@ status_t LSM6DS3_ACC_GYRO_R_HPCF_XL(void *handle, LSM6DS3_ACC_GYRO_HPCF_XL_t *va
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM6DS3_ACC_GYRO_W_LOW_PASS_ON_6D(void *handle, LSM6DS3_ACC_GYRO_LOW_PASS_ON_6D_t newValue)
+mems_status_t  LSM6DS3_ACC_GYRO_W_LOW_PASS_ON_6D(void *handle, LSM6DS3_ACC_GYRO_LOW_PASS_ON_6D_t newValue)
 {
   u8_t value;
 
@@ -3317,7 +3317,7 @@ status_t  LSM6DS3_ACC_GYRO_W_LOW_PASS_ON_6D(void *handle, LSM6DS3_ACC_GYRO_LOW_P
 * Output         : Status of LOW_PASS_ON_6D see LSM6DS3_ACC_GYRO_LOW_PASS_ON_6D_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_LOW_PASS_ON_6D(void *handle, LSM6DS3_ACC_GYRO_LOW_PASS_ON_6D_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_LOW_PASS_ON_6D(void *handle, LSM6DS3_ACC_GYRO_LOW_PASS_ON_6D_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_CTRL8_XL, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -3334,7 +3334,7 @@ status_t LSM6DS3_ACC_GYRO_R_LOW_PASS_ON_6D(void *handle, LSM6DS3_ACC_GYRO_LOW_PA
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM6DS3_ACC_GYRO_W_HP_SLOPE_XL(void *handle, LSM6DS3_ACC_GYRO_HP_SLOPE_XL_t newValue)
+mems_status_t  LSM6DS3_ACC_GYRO_W_HP_SLOPE_XL(void *handle, LSM6DS3_ACC_GYRO_HP_SLOPE_XL_t newValue)
 {
   u8_t value;
 
@@ -3357,7 +3357,7 @@ status_t  LSM6DS3_ACC_GYRO_W_HP_SLOPE_XL(void *handle, LSM6DS3_ACC_GYRO_HP_SLOPE
 * Output         : Status of HP_SLOPE_XL_EN see LSM6DS3_ACC_GYRO_HP_SLOPE_XL_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_HP_SLOPE_XL(void *handle, LSM6DS3_ACC_GYRO_HP_SLOPE_XL_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_HP_SLOPE_XL(void *handle, LSM6DS3_ACC_GYRO_HP_SLOPE_XL_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_CTRL8_XL, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -3374,7 +3374,7 @@ status_t LSM6DS3_ACC_GYRO_R_HP_SLOPE_XL(void *handle, LSM6DS3_ACC_GYRO_HP_SLOPE_
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM6DS3_ACC_GYRO_W_XEN_XL(void *handle, LSM6DS3_ACC_GYRO_XEN_XL_t newValue)
+mems_status_t  LSM6DS3_ACC_GYRO_W_XEN_XL(void *handle, LSM6DS3_ACC_GYRO_XEN_XL_t newValue)
 {
   u8_t value;
 
@@ -3397,7 +3397,7 @@ status_t  LSM6DS3_ACC_GYRO_W_XEN_XL(void *handle, LSM6DS3_ACC_GYRO_XEN_XL_t newV
 * Output         : Status of XEN_XL see LSM6DS3_ACC_GYRO_XEN_XL_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_XEN_XL(void *handle, LSM6DS3_ACC_GYRO_XEN_XL_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_XEN_XL(void *handle, LSM6DS3_ACC_GYRO_XEN_XL_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_CTRL9_XL, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -3413,7 +3413,7 @@ status_t LSM6DS3_ACC_GYRO_R_XEN_XL(void *handle, LSM6DS3_ACC_GYRO_XEN_XL_t *valu
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM6DS3_ACC_GYRO_W_YEN_XL(void *handle, LSM6DS3_ACC_GYRO_YEN_XL_t newValue)
+mems_status_t  LSM6DS3_ACC_GYRO_W_YEN_XL(void *handle, LSM6DS3_ACC_GYRO_YEN_XL_t newValue)
 {
   u8_t value;
 
@@ -3436,7 +3436,7 @@ status_t  LSM6DS3_ACC_GYRO_W_YEN_XL(void *handle, LSM6DS3_ACC_GYRO_YEN_XL_t newV
 * Output         : Status of YEN_XL see LSM6DS3_ACC_GYRO_YEN_XL_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_YEN_XL(void *handle, LSM6DS3_ACC_GYRO_YEN_XL_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_YEN_XL(void *handle, LSM6DS3_ACC_GYRO_YEN_XL_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_CTRL9_XL, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -3453,7 +3453,7 @@ status_t LSM6DS3_ACC_GYRO_R_YEN_XL(void *handle, LSM6DS3_ACC_GYRO_YEN_XL_t *valu
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM6DS3_ACC_GYRO_W_ZEN_XL(void *handle, LSM6DS3_ACC_GYRO_ZEN_XL_t newValue)
+mems_status_t  LSM6DS3_ACC_GYRO_W_ZEN_XL(void *handle, LSM6DS3_ACC_GYRO_ZEN_XL_t newValue)
 {
   u8_t value;
 
@@ -3476,7 +3476,7 @@ status_t  LSM6DS3_ACC_GYRO_W_ZEN_XL(void *handle, LSM6DS3_ACC_GYRO_ZEN_XL_t newV
 * Output         : Status of ZEN_XL see LSM6DS3_ACC_GYRO_ZEN_XL_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_ZEN_XL(void *handle, LSM6DS3_ACC_GYRO_ZEN_XL_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_ZEN_XL(void *handle, LSM6DS3_ACC_GYRO_ZEN_XL_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_CTRL9_XL, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -3493,7 +3493,7 @@ status_t LSM6DS3_ACC_GYRO_R_ZEN_XL(void *handle, LSM6DS3_ACC_GYRO_ZEN_XL_t *valu
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM6DS3_ACC_GYRO_W_SOFT(void *handle, LSM6DS3_ACC_GYRO_SOFT_t newValue)
+mems_status_t  LSM6DS3_ACC_GYRO_W_SOFT(void *handle, LSM6DS3_ACC_GYRO_SOFT_t newValue)
 {
   u8_t value;
 
@@ -3516,7 +3516,7 @@ status_t  LSM6DS3_ACC_GYRO_W_SOFT(void *handle, LSM6DS3_ACC_GYRO_SOFT_t newValue
 * Output         : Status of SOFT_EN see LSM6DS3_ACC_GYRO_SOFT_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_SOFT(void *handle, LSM6DS3_ACC_GYRO_SOFT_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_SOFT(void *handle, LSM6DS3_ACC_GYRO_SOFT_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_CTRL9_XL, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -3533,7 +3533,7 @@ status_t LSM6DS3_ACC_GYRO_R_SOFT(void *handle, LSM6DS3_ACC_GYRO_SOFT_t *value)
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM6DS3_ACC_GYRO_W_SignifcantMotion(void *handle, LSM6DS3_ACC_GYRO_SIGN_MOTION_EN_t newValue)
+mems_status_t  LSM6DS3_ACC_GYRO_W_SignifcantMotion(void *handle, LSM6DS3_ACC_GYRO_SIGN_MOTION_EN_t newValue)
 {
   u8_t value;
 
@@ -3556,7 +3556,7 @@ status_t  LSM6DS3_ACC_GYRO_W_SignifcantMotion(void *handle, LSM6DS3_ACC_GYRO_SIG
 * Output         : Status of SIGN_MOTION_EN see LSM6DS3_ACC_GYRO_SIGN_MOTION_EN_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_SignifcantMotion(void *handle, LSM6DS3_ACC_GYRO_SIGN_MOTION_EN_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_SignifcantMotion(void *handle, LSM6DS3_ACC_GYRO_SIGN_MOTION_EN_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_CTRL10_C, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -3573,7 +3573,7 @@ status_t LSM6DS3_ACC_GYRO_R_SignifcantMotion(void *handle, LSM6DS3_ACC_GYRO_SIGN
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM6DS3_ACC_GYRO_W_PedoStepReset(void *handle, LSM6DS3_ACC_GYRO_PEDO_RST_STEP_t newValue)
+mems_status_t  LSM6DS3_ACC_GYRO_W_PedoStepReset(void *handle, LSM6DS3_ACC_GYRO_PEDO_RST_STEP_t newValue)
 {
   u8_t value;
 
@@ -3596,7 +3596,7 @@ status_t  LSM6DS3_ACC_GYRO_W_PedoStepReset(void *handle, LSM6DS3_ACC_GYRO_PEDO_R
 * Output         : Status of PEDO_RST_STEP see LSM6DS3_ACC_GYRO_PEDO_RST_STEP_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_PedoStepReset(void *handle, LSM6DS3_ACC_GYRO_PEDO_RST_STEP_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_PedoStepReset(void *handle, LSM6DS3_ACC_GYRO_PEDO_RST_STEP_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_CTRL10_C, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -3613,7 +3613,7 @@ status_t LSM6DS3_ACC_GYRO_R_PedoStepReset(void *handle, LSM6DS3_ACC_GYRO_PEDO_RS
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM6DS3_ACC_GYRO_W_XEN_G(void *handle, LSM6DS3_ACC_GYRO_XEN_G_t newValue)
+mems_status_t  LSM6DS3_ACC_GYRO_W_XEN_G(void *handle, LSM6DS3_ACC_GYRO_XEN_G_t newValue)
 {
   u8_t value;
 
@@ -3636,7 +3636,7 @@ status_t  LSM6DS3_ACC_GYRO_W_XEN_G(void *handle, LSM6DS3_ACC_GYRO_XEN_G_t newVal
 * Output         : Status of XEN_G see LSM6DS3_ACC_GYRO_XEN_G_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_XEN_G(void *handle, LSM6DS3_ACC_GYRO_XEN_G_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_XEN_G(void *handle, LSM6DS3_ACC_GYRO_XEN_G_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_CTRL10_C, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -3653,7 +3653,7 @@ status_t LSM6DS3_ACC_GYRO_R_XEN_G(void *handle, LSM6DS3_ACC_GYRO_XEN_G_t *value)
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM6DS3_ACC_GYRO_W_YEN_G(void *handle, LSM6DS3_ACC_GYRO_YEN_G_t newValue)
+mems_status_t  LSM6DS3_ACC_GYRO_W_YEN_G(void *handle, LSM6DS3_ACC_GYRO_YEN_G_t newValue)
 {
   u8_t value;
 
@@ -3676,7 +3676,7 @@ status_t  LSM6DS3_ACC_GYRO_W_YEN_G(void *handle, LSM6DS3_ACC_GYRO_YEN_G_t newVal
 * Output         : Status of YEN_G see LSM6DS3_ACC_GYRO_YEN_G_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_YEN_G(void *handle, LSM6DS3_ACC_GYRO_YEN_G_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_YEN_G(void *handle, LSM6DS3_ACC_GYRO_YEN_G_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_CTRL10_C, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -3693,7 +3693,7 @@ status_t LSM6DS3_ACC_GYRO_R_YEN_G(void *handle, LSM6DS3_ACC_GYRO_YEN_G_t *value)
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM6DS3_ACC_GYRO_W_ZEN_G(void *handle, LSM6DS3_ACC_GYRO_ZEN_G_t newValue)
+mems_status_t  LSM6DS3_ACC_GYRO_W_ZEN_G(void *handle, LSM6DS3_ACC_GYRO_ZEN_G_t newValue)
 {
   u8_t value;
 
@@ -3716,7 +3716,7 @@ status_t  LSM6DS3_ACC_GYRO_W_ZEN_G(void *handle, LSM6DS3_ACC_GYRO_ZEN_G_t newVal
 * Output         : Status of ZEN_G see LSM6DS3_ACC_GYRO_ZEN_G_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_ZEN_G(void *handle, LSM6DS3_ACC_GYRO_ZEN_G_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_ZEN_G(void *handle, LSM6DS3_ACC_GYRO_ZEN_G_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_CTRL10_C, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -3733,7 +3733,7 @@ status_t LSM6DS3_ACC_GYRO_R_ZEN_G(void *handle, LSM6DS3_ACC_GYRO_ZEN_G_t *value)
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM6DS3_ACC_GYRO_W_FUNC_EN(void *handle, LSM6DS3_ACC_GYRO_FUNC_EN_t newValue)
+mems_status_t  LSM6DS3_ACC_GYRO_W_FUNC_EN(void *handle, LSM6DS3_ACC_GYRO_FUNC_EN_t newValue)
 {
   u8_t value;
 
@@ -3756,7 +3756,7 @@ status_t  LSM6DS3_ACC_GYRO_W_FUNC_EN(void *handle, LSM6DS3_ACC_GYRO_FUNC_EN_t ne
 * Output         : Status of FUNC_EN see LSM6DS3_ACC_GYRO_FUNC_EN_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_FUNC_EN(void *handle, LSM6DS3_ACC_GYRO_FUNC_EN_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_FUNC_EN(void *handle, LSM6DS3_ACC_GYRO_FUNC_EN_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_CTRL10_C, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -3773,7 +3773,7 @@ status_t LSM6DS3_ACC_GYRO_R_FUNC_EN(void *handle, LSM6DS3_ACC_GYRO_FUNC_EN_t *va
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM6DS3_ACC_GYRO_W_I2C_MASTER_Enable(void *handle, LSM6DS3_ACC_GYRO_MASTER_ON_t newValue)
+mems_status_t  LSM6DS3_ACC_GYRO_W_I2C_MASTER_Enable(void *handle, LSM6DS3_ACC_GYRO_MASTER_ON_t newValue)
 {
   u8_t value;
 
@@ -3796,7 +3796,7 @@ status_t  LSM6DS3_ACC_GYRO_W_I2C_MASTER_Enable(void *handle, LSM6DS3_ACC_GYRO_MA
 * Output         : Status of MASTER_ON see LSM6DS3_ACC_GYRO_MASTER_ON_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_I2C_MASTER_Enable(void *handle, LSM6DS3_ACC_GYRO_MASTER_ON_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_I2C_MASTER_Enable(void *handle, LSM6DS3_ACC_GYRO_MASTER_ON_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_MASTER_CONFIG, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -3813,7 +3813,7 @@ status_t LSM6DS3_ACC_GYRO_R_I2C_MASTER_Enable(void *handle, LSM6DS3_ACC_GYRO_MAS
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM6DS3_ACC_GYRO_W_IronCorrection_EN(void *handle, LSM6DS3_ACC_GYRO_IRON_EN_t newValue)
+mems_status_t  LSM6DS3_ACC_GYRO_W_IronCorrection_EN(void *handle, LSM6DS3_ACC_GYRO_IRON_EN_t newValue)
 {
   u8_t value;
 
@@ -3836,7 +3836,7 @@ status_t  LSM6DS3_ACC_GYRO_W_IronCorrection_EN(void *handle, LSM6DS3_ACC_GYRO_IR
 * Output         : Status of IRON_EN see LSM6DS3_ACC_GYRO_IRON_EN_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_IronCorrection_EN(void *handle, LSM6DS3_ACC_GYRO_IRON_EN_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_IronCorrection_EN(void *handle, LSM6DS3_ACC_GYRO_IRON_EN_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_MASTER_CONFIG, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -3853,7 +3853,7 @@ status_t LSM6DS3_ACC_GYRO_R_IronCorrection_EN(void *handle, LSM6DS3_ACC_GYRO_IRO
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM6DS3_ACC_GYRO_W_PASS_THRU_MODE(void *handle, LSM6DS3_ACC_GYRO_PASS_THRU_MODE_t newValue)
+mems_status_t  LSM6DS3_ACC_GYRO_W_PASS_THRU_MODE(void *handle, LSM6DS3_ACC_GYRO_PASS_THRU_MODE_t newValue)
 {
   u8_t value;
 
@@ -3876,7 +3876,7 @@ status_t  LSM6DS3_ACC_GYRO_W_PASS_THRU_MODE(void *handle, LSM6DS3_ACC_GYRO_PASS_
 * Output         : Status of PASS_THRU_MODE see LSM6DS3_ACC_GYRO_PASS_THRU_MODE_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_PASS_THRU_MODE(void *handle, LSM6DS3_ACC_GYRO_PASS_THRU_MODE_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_PASS_THRU_MODE(void *handle, LSM6DS3_ACC_GYRO_PASS_THRU_MODE_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_MASTER_CONFIG, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -3893,7 +3893,7 @@ status_t LSM6DS3_ACC_GYRO_R_PASS_THRU_MODE(void *handle, LSM6DS3_ACC_GYRO_PASS_T
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM6DS3_ACC_GYRO_W_PULL_UP_EN(void *handle, LSM6DS3_ACC_GYRO_PULL_UP_EN_t newValue)
+mems_status_t  LSM6DS3_ACC_GYRO_W_PULL_UP_EN(void *handle, LSM6DS3_ACC_GYRO_PULL_UP_EN_t newValue)
 {
   u8_t value;
 
@@ -3916,7 +3916,7 @@ status_t  LSM6DS3_ACC_GYRO_W_PULL_UP_EN(void *handle, LSM6DS3_ACC_GYRO_PULL_UP_E
 * Output         : Status of PULL_UP_EN see LSM6DS3_ACC_GYRO_PULL_UP_EN_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_PULL_UP_EN(void *handle, LSM6DS3_ACC_GYRO_PULL_UP_EN_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_PULL_UP_EN(void *handle, LSM6DS3_ACC_GYRO_PULL_UP_EN_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_MASTER_CONFIG, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -3933,7 +3933,7 @@ status_t LSM6DS3_ACC_GYRO_R_PULL_UP_EN(void *handle, LSM6DS3_ACC_GYRO_PULL_UP_EN
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM6DS3_ACC_GYRO_W_SensorHUB_Trigger_Sel(void *handle, LSM6DS3_ACC_GYRO_START_CONFIG_t newValue)
+mems_status_t  LSM6DS3_ACC_GYRO_W_SensorHUB_Trigger_Sel(void *handle, LSM6DS3_ACC_GYRO_START_CONFIG_t newValue)
 {
   u8_t value;
 
@@ -3956,7 +3956,7 @@ status_t  LSM6DS3_ACC_GYRO_W_SensorHUB_Trigger_Sel(void *handle, LSM6DS3_ACC_GYR
 * Output         : Status of START_CONFIG see LSM6DS3_ACC_GYRO_START_CONFIG_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_SensorHUB_Trigger_Sel(void *handle, LSM6DS3_ACC_GYRO_START_CONFIG_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_SensorHUB_Trigger_Sel(void *handle, LSM6DS3_ACC_GYRO_START_CONFIG_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_MASTER_CONFIG, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -3973,7 +3973,7 @@ status_t LSM6DS3_ACC_GYRO_R_SensorHUB_Trigger_Sel(void *handle, LSM6DS3_ACC_GYRO
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM6DS3_ACC_GYRO_W_DATA_VAL_SEL_FIFO(void *handle, LSM6DS3_ACC_GYRO_DATA_VAL_SEL_FIFO_t newValue)
+mems_status_t  LSM6DS3_ACC_GYRO_W_DATA_VAL_SEL_FIFO(void *handle, LSM6DS3_ACC_GYRO_DATA_VAL_SEL_FIFO_t newValue)
 {
   u8_t value;
 
@@ -3996,7 +3996,7 @@ status_t  LSM6DS3_ACC_GYRO_W_DATA_VAL_SEL_FIFO(void *handle, LSM6DS3_ACC_GYRO_DA
 * Output         : Status of DATA_VAL_SEL_FIFO see LSM6DS3_ACC_GYRO_DATA_VAL_SEL_FIFO_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_DATA_VAL_SEL_FIFO(void *handle, LSM6DS3_ACC_GYRO_DATA_VAL_SEL_FIFO_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_DATA_VAL_SEL_FIFO(void *handle, LSM6DS3_ACC_GYRO_DATA_VAL_SEL_FIFO_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_MASTER_CONFIG, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -4013,7 +4013,7 @@ status_t LSM6DS3_ACC_GYRO_R_DATA_VAL_SEL_FIFO(void *handle, LSM6DS3_ACC_GYRO_DAT
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM6DS3_ACC_GYRO_W_DRDY_ON_INT1(void *handle, LSM6DS3_ACC_GYRO_DRDY_ON_INT1_t newValue)
+mems_status_t  LSM6DS3_ACC_GYRO_W_DRDY_ON_INT1(void *handle, LSM6DS3_ACC_GYRO_DRDY_ON_INT1_t newValue)
 {
   u8_t value;
 
@@ -4036,7 +4036,7 @@ status_t  LSM6DS3_ACC_GYRO_W_DRDY_ON_INT1(void *handle, LSM6DS3_ACC_GYRO_DRDY_ON
 * Output         : Status of DRDY_ON_INT1 see LSM6DS3_ACC_GYRO_DRDY_ON_INT1_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_DRDY_ON_INT1(void *handle, LSM6DS3_ACC_GYRO_DRDY_ON_INT1_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_DRDY_ON_INT1(void *handle, LSM6DS3_ACC_GYRO_DRDY_ON_INT1_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_MASTER_CONFIG, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -4053,7 +4053,7 @@ status_t LSM6DS3_ACC_GYRO_R_DRDY_ON_INT1(void *handle, LSM6DS3_ACC_GYRO_DRDY_ON_
 * Output         : Status of Z_WU see LSM6DS3_ACC_GYRO_Z_WU_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_Z_WU(void *handle, LSM6DS3_ACC_GYRO_Z_WU_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_Z_WU(void *handle, LSM6DS3_ACC_GYRO_Z_WU_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_WAKE_UP_SRC, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -4070,7 +4070,7 @@ status_t LSM6DS3_ACC_GYRO_R_Z_WU(void *handle, LSM6DS3_ACC_GYRO_Z_WU_t *value)
 * Output         : Status of Y_WU see LSM6DS3_ACC_GYRO_Y_WU_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_Y_WU(void *handle, LSM6DS3_ACC_GYRO_Y_WU_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_Y_WU(void *handle, LSM6DS3_ACC_GYRO_Y_WU_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_WAKE_UP_SRC, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -4087,7 +4087,7 @@ status_t LSM6DS3_ACC_GYRO_R_Y_WU(void *handle, LSM6DS3_ACC_GYRO_Y_WU_t *value)
 * Output         : Status of X_WU see LSM6DS3_ACC_GYRO_X_WU_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_X_WU(void *handle, LSM6DS3_ACC_GYRO_X_WU_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_X_WU(void *handle, LSM6DS3_ACC_GYRO_X_WU_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_WAKE_UP_SRC, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -4104,7 +4104,7 @@ status_t LSM6DS3_ACC_GYRO_R_X_WU(void *handle, LSM6DS3_ACC_GYRO_X_WU_t *value)
 * Output         : Status of WU_EV_STATUS see LSM6DS3_ACC_GYRO_WU_EV_STATUS_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_WU_EV_STATUS(void *handle, LSM6DS3_ACC_GYRO_WU_EV_STATUS_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_WU_EV_STATUS(void *handle, LSM6DS3_ACC_GYRO_WU_EV_STATUS_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_WAKE_UP_SRC, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -4121,7 +4121,7 @@ status_t LSM6DS3_ACC_GYRO_R_WU_EV_STATUS(void *handle, LSM6DS3_ACC_GYRO_WU_EV_ST
 * Output         : Status of SLEEP_EV_STATUS see LSM6DS3_ACC_GYRO_SLEEP_EV_STATUS_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_SLEEP_EV_STATUS(void *handle, LSM6DS3_ACC_GYRO_SLEEP_EV_STATUS_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_SLEEP_EV_STATUS(void *handle, LSM6DS3_ACC_GYRO_SLEEP_EV_STATUS_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_WAKE_UP_SRC, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -4138,7 +4138,7 @@ status_t LSM6DS3_ACC_GYRO_R_SLEEP_EV_STATUS(void *handle, LSM6DS3_ACC_GYRO_SLEEP
 * Output         : Status of FF_EV_STATUS see LSM6DS3_ACC_GYRO_FF_EV_STATUS_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_FF_EV_STATUS(void *handle, LSM6DS3_ACC_GYRO_FF_EV_STATUS_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_FF_EV_STATUS(void *handle, LSM6DS3_ACC_GYRO_FF_EV_STATUS_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_WAKE_UP_SRC, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -4155,7 +4155,7 @@ status_t LSM6DS3_ACC_GYRO_R_FF_EV_STATUS(void *handle, LSM6DS3_ACC_GYRO_FF_EV_ST
 * Output         : Status of Z_TAP see LSM6DS3_ACC_GYRO_Z_TAP_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_Z_TAP(void *handle, LSM6DS3_ACC_GYRO_Z_TAP_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_Z_TAP(void *handle, LSM6DS3_ACC_GYRO_Z_TAP_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_TAP_SRC, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -4172,7 +4172,7 @@ status_t LSM6DS3_ACC_GYRO_R_Z_TAP(void *handle, LSM6DS3_ACC_GYRO_Z_TAP_t *value)
 * Output         : Status of Y_TAP see LSM6DS3_ACC_GYRO_Y_TAP_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_Y_TAP(void *handle, LSM6DS3_ACC_GYRO_Y_TAP_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_Y_TAP(void *handle, LSM6DS3_ACC_GYRO_Y_TAP_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_TAP_SRC, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -4189,7 +4189,7 @@ status_t LSM6DS3_ACC_GYRO_R_Y_TAP(void *handle, LSM6DS3_ACC_GYRO_Y_TAP_t *value)
 * Output         : Status of X_TAP see LSM6DS3_ACC_GYRO_X_TAP_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_X_TAP(void *handle, LSM6DS3_ACC_GYRO_X_TAP_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_X_TAP(void *handle, LSM6DS3_ACC_GYRO_X_TAP_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_TAP_SRC, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -4206,7 +4206,7 @@ status_t LSM6DS3_ACC_GYRO_R_X_TAP(void *handle, LSM6DS3_ACC_GYRO_X_TAP_t *value)
 * Output         : Status of TAP_SIGN see LSM6DS3_ACC_GYRO_TAP_SIGN_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_TAP_SIGN(void *handle, LSM6DS3_ACC_GYRO_TAP_SIGN_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_TAP_SIGN(void *handle, LSM6DS3_ACC_GYRO_TAP_SIGN_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_TAP_SRC, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -4223,7 +4223,7 @@ status_t LSM6DS3_ACC_GYRO_R_TAP_SIGN(void *handle, LSM6DS3_ACC_GYRO_TAP_SIGN_t *
 * Output         : Status of DOUBLE_TAP_EV_STATUS see LSM6DS3_ACC_GYRO_DOUBLE_TAP_EV_STATUS_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_DOUBLE_TAP_EV_STATUS(void *handle, LSM6DS3_ACC_GYRO_DOUBLE_TAP_EV_STATUS_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_DOUBLE_TAP_EV_STATUS(void *handle, LSM6DS3_ACC_GYRO_DOUBLE_TAP_EV_STATUS_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_TAP_SRC, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -4240,7 +4240,7 @@ status_t LSM6DS3_ACC_GYRO_R_DOUBLE_TAP_EV_STATUS(void *handle, LSM6DS3_ACC_GYRO_
 * Output         : Status of SINGLE_TAP_EV_STATUS see LSM6DS3_ACC_GYRO_SINGLE_TAP_EV_STATUS_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_SINGLE_TAP_EV_STATUS(void *handle, LSM6DS3_ACC_GYRO_SINGLE_TAP_EV_STATUS_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_SINGLE_TAP_EV_STATUS(void *handle, LSM6DS3_ACC_GYRO_SINGLE_TAP_EV_STATUS_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_TAP_SRC, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -4257,7 +4257,7 @@ status_t LSM6DS3_ACC_GYRO_R_SINGLE_TAP_EV_STATUS(void *handle, LSM6DS3_ACC_GYRO_
 * Output         : Status of TAP_EV_STATUS see LSM6DS3_ACC_GYRO_TAP_EV_STATUS_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_TAP_EV_STATUS(void *handle, LSM6DS3_ACC_GYRO_TAP_EV_STATUS_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_TAP_EV_STATUS(void *handle, LSM6DS3_ACC_GYRO_TAP_EV_STATUS_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_TAP_SRC, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -4274,7 +4274,7 @@ status_t LSM6DS3_ACC_GYRO_R_TAP_EV_STATUS(void *handle, LSM6DS3_ACC_GYRO_TAP_EV_
 * Output         : Status of DSD_XL see LSM6DS3_ACC_GYRO_DSD_XL_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_DSD_XL(void *handle, LSM6DS3_ACC_GYRO_DSD_XL_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_DSD_XL(void *handle, LSM6DS3_ACC_GYRO_DSD_XL_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_D6D_SRC, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -4291,7 +4291,7 @@ status_t LSM6DS3_ACC_GYRO_R_DSD_XL(void *handle, LSM6DS3_ACC_GYRO_DSD_XL_t *valu
 * Output         : Status of DSD_XH see LSM6DS3_ACC_GYRO_DSD_XH_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_DSD_XH(void *handle, LSM6DS3_ACC_GYRO_DSD_XH_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_DSD_XH(void *handle, LSM6DS3_ACC_GYRO_DSD_XH_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_D6D_SRC, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -4308,7 +4308,7 @@ status_t LSM6DS3_ACC_GYRO_R_DSD_XH(void *handle, LSM6DS3_ACC_GYRO_DSD_XH_t *valu
 * Output         : Status of DSD_YL see LSM6DS3_ACC_GYRO_DSD_YL_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_DSD_YL(void *handle, LSM6DS3_ACC_GYRO_DSD_YL_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_DSD_YL(void *handle, LSM6DS3_ACC_GYRO_DSD_YL_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_D6D_SRC, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -4325,7 +4325,7 @@ status_t LSM6DS3_ACC_GYRO_R_DSD_YL(void *handle, LSM6DS3_ACC_GYRO_DSD_YL_t *valu
 * Output         : Status of DSD_YH see LSM6DS3_ACC_GYRO_DSD_YH_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_DSD_YH(void *handle, LSM6DS3_ACC_GYRO_DSD_YH_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_DSD_YH(void *handle, LSM6DS3_ACC_GYRO_DSD_YH_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_D6D_SRC, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -4342,7 +4342,7 @@ status_t LSM6DS3_ACC_GYRO_R_DSD_YH(void *handle, LSM6DS3_ACC_GYRO_DSD_YH_t *valu
 * Output         : Status of DSD_ZL see LSM6DS3_ACC_GYRO_DSD_ZL_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_DSD_ZL(void *handle, LSM6DS3_ACC_GYRO_DSD_ZL_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_DSD_ZL(void *handle, LSM6DS3_ACC_GYRO_DSD_ZL_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_D6D_SRC, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -4359,7 +4359,7 @@ status_t LSM6DS3_ACC_GYRO_R_DSD_ZL(void *handle, LSM6DS3_ACC_GYRO_DSD_ZL_t *valu
 * Output         : Status of DSD_ZH see LSM6DS3_ACC_GYRO_DSD_ZH_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_DSD_ZH(void *handle, LSM6DS3_ACC_GYRO_DSD_ZH_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_DSD_ZH(void *handle, LSM6DS3_ACC_GYRO_DSD_ZH_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_D6D_SRC, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -4376,7 +4376,7 @@ status_t LSM6DS3_ACC_GYRO_R_DSD_ZH(void *handle, LSM6DS3_ACC_GYRO_DSD_ZH_t *valu
 * Output         : Status of D6D_EV_STATUS see LSM6DS3_ACC_GYRO_D6D_EV_STATUS_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_D6D_EV_STATUS(void *handle, LSM6DS3_ACC_GYRO_D6D_EV_STATUS_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_D6D_EV_STATUS(void *handle, LSM6DS3_ACC_GYRO_D6D_EV_STATUS_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_D6D_SRC, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -4393,7 +4393,7 @@ status_t LSM6DS3_ACC_GYRO_R_D6D_EV_STATUS(void *handle, LSM6DS3_ACC_GYRO_D6D_EV_
 * Output         : Status of XLDA see LSM6DS3_ACC_GYRO_XLDA_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_XLDA(void *handle, LSM6DS3_ACC_GYRO_XLDA_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_XLDA(void *handle, LSM6DS3_ACC_GYRO_XLDA_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_STATUS_REG, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -4410,7 +4410,7 @@ status_t LSM6DS3_ACC_GYRO_R_XLDA(void *handle, LSM6DS3_ACC_GYRO_XLDA_t *value)
 * Output         : Status of GDA see LSM6DS3_ACC_GYRO_GDA_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_GDA(void *handle, LSM6DS3_ACC_GYRO_GDA_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_GDA(void *handle, LSM6DS3_ACC_GYRO_GDA_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_STATUS_REG, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -4427,7 +4427,7 @@ status_t LSM6DS3_ACC_GYRO_R_GDA(void *handle, LSM6DS3_ACC_GYRO_GDA_t *value)
 * Output         : Status of GDA see LSM6DS3_ACC_GYRO_TDA_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_TDA(void *handle, LSM6DS3_ACC_GYRO_TDA_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_TDA(void *handle, LSM6DS3_ACC_GYRO_TDA_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_STATUS_REG, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -4444,7 +4444,7 @@ status_t LSM6DS3_ACC_GYRO_R_TDA(void *handle, LSM6DS3_ACC_GYRO_TDA_t *value)
 * Output         : Status of EV_BOOT see LSM6DS3_ACC_GYRO_EV_BOOT_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_EV_BOOT(void *handle, LSM6DS3_ACC_GYRO_EV_BOOT_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_EV_BOOT(void *handle, LSM6DS3_ACC_GYRO_EV_BOOT_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_STATUS_REG, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -4461,7 +4461,7 @@ status_t LSM6DS3_ACC_GYRO_R_EV_BOOT(void *handle, LSM6DS3_ACC_GYRO_EV_BOOT_t *va
 * Output         : Status of DIFF_FIFO
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_FIFONumOfEntries(void *handle, u16_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_FIFONumOfEntries(void *handle, u16_t *value)
 {
   u8_t valueH, valueL;
 
@@ -4491,7 +4491,7 @@ status_t LSM6DS3_ACC_GYRO_R_FIFONumOfEntries(void *handle, u16_t *value)
 * Output         : Status of FIFO_EMPTY see LSM6DS3_ACC_GYRO_FIFO_EMPTY_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_FIFOEmpty(void *handle, LSM6DS3_ACC_GYRO_FIFO_EMPTY_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_FIFOEmpty(void *handle, LSM6DS3_ACC_GYRO_FIFO_EMPTY_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_FIFO_STATUS2, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -4508,7 +4508,7 @@ status_t LSM6DS3_ACC_GYRO_R_FIFOEmpty(void *handle, LSM6DS3_ACC_GYRO_FIFO_EMPTY_
 * Output         : Status of FIFO_FULL see LSM6DS3_ACC_GYRO_FIFO_FULL_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_FIFOFull(void *handle, LSM6DS3_ACC_GYRO_FIFO_FULL_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_FIFOFull(void *handle, LSM6DS3_ACC_GYRO_FIFO_FULL_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_FIFO_STATUS2, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -4525,7 +4525,7 @@ status_t LSM6DS3_ACC_GYRO_R_FIFOFull(void *handle, LSM6DS3_ACC_GYRO_FIFO_FULL_t 
 * Output         : Status of OVERRUN see LSM6DS3_ACC_GYRO_OVERRUN_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_OVERRUN(void *handle, LSM6DS3_ACC_GYRO_OVERRUN_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_OVERRUN(void *handle, LSM6DS3_ACC_GYRO_OVERRUN_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_FIFO_STATUS2, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -4542,7 +4542,7 @@ status_t LSM6DS3_ACC_GYRO_R_OVERRUN(void *handle, LSM6DS3_ACC_GYRO_OVERRUN_t *va
 * Output         : Status of WTM see LSM6DS3_ACC_GYRO_WTM_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_WaterMark(void *handle, LSM6DS3_ACC_GYRO_WTM_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_WaterMark(void *handle, LSM6DS3_ACC_GYRO_WTM_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_FIFO_STATUS2, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -4559,7 +4559,7 @@ status_t LSM6DS3_ACC_GYRO_R_WaterMark(void *handle, LSM6DS3_ACC_GYRO_WTM_t *valu
 * Output         : Status of FIFO_PATTERN
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_FIFOPattern(void *handle, u16_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_FIFOPattern(void *handle, u16_t *value)
 {
   u8_t valueH, valueL;
 
@@ -4589,7 +4589,7 @@ status_t LSM6DS3_ACC_GYRO_R_FIFOPattern(void *handle, u16_t *value)
 * Output         : Status of SENS_HUB_END see LSM6DS3_ACC_GYRO_SENS_HUB_END_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_SENS_HUB_END(void *handle, LSM6DS3_ACC_GYRO_SENS_HUB_END_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_SENS_HUB_END(void *handle, LSM6DS3_ACC_GYRO_SENS_HUB_END_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_FUNC_SRC, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -4606,7 +4606,7 @@ status_t LSM6DS3_ACC_GYRO_R_SENS_HUB_END(void *handle, LSM6DS3_ACC_GYRO_SENS_HUB
 * Output         : Status of SOFT_IRON_END see LSM6DS3_ACC_GYRO_SOFT_IRON_END_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_SOFT_IRON_END(void *handle, LSM6DS3_ACC_GYRO_SOFT_IRON_END_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_SOFT_IRON_END(void *handle, LSM6DS3_ACC_GYRO_SOFT_IRON_END_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_FUNC_SRC, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -4623,7 +4623,7 @@ status_t LSM6DS3_ACC_GYRO_R_SOFT_IRON_END(void *handle, LSM6DS3_ACC_GYRO_SOFT_IR
 * Output         : Status of STEP_OVERFLOW see LSM6DS3_ACC_GYRO_STEP_OVERFLOW_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_STEP_OVERFLOW(void *handle, LSM6DS3_ACC_GYRO_STEP_OVERFLOW_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_STEP_OVERFLOW(void *handle, LSM6DS3_ACC_GYRO_STEP_OVERFLOW_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_FUNC_SRC, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -4640,7 +4640,7 @@ status_t LSM6DS3_ACC_GYRO_R_STEP_OVERFLOW(void *handle, LSM6DS3_ACC_GYRO_STEP_OV
 * Output         : Status of STEP_COUNT_DELTA_IA see LSM6DS3_ACC_GYRO_STEP_COUNT_DELTA_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_STEP_COUNT_DELTA(void *handle, LSM6DS3_ACC_GYRO_STEP_COUNT_DELTA_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_STEP_COUNT_DELTA(void *handle, LSM6DS3_ACC_GYRO_STEP_COUNT_DELTA_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_FUNC_SRC, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -4657,7 +4657,7 @@ status_t LSM6DS3_ACC_GYRO_R_STEP_COUNT_DELTA(void *handle, LSM6DS3_ACC_GYRO_STEP
 * Output         : Status of PEDO_EV_STATUS see LSM6DS3_ACC_GYRO_PEDO_EV_STATUS_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_PEDO_EV_STATUS(void *handle, LSM6DS3_ACC_GYRO_PEDO_EV_STATUS_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_PEDO_EV_STATUS(void *handle, LSM6DS3_ACC_GYRO_PEDO_EV_STATUS_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_FUNC_SRC, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -4674,7 +4674,7 @@ status_t LSM6DS3_ACC_GYRO_R_PEDO_EV_STATUS(void *handle, LSM6DS3_ACC_GYRO_PEDO_E
 * Output         : Status of TILT_EV_STATUS see LSM6DS3_ACC_GYRO_TILT_EV_STATUS_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_TILT_EV_STATUS(void *handle, LSM6DS3_ACC_GYRO_TILT_EV_STATUS_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_TILT_EV_STATUS(void *handle, LSM6DS3_ACC_GYRO_TILT_EV_STATUS_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_FUNC_SRC, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -4691,7 +4691,7 @@ status_t LSM6DS3_ACC_GYRO_R_TILT_EV_STATUS(void *handle, LSM6DS3_ACC_GYRO_TILT_E
 * Output         : Status of SIGN_MOT_EV_STATUS see LSM6DS3_ACC_GYRO_SIGN_MOT_EV_STATUS_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_SIGN_MOT_EV_STATUS(void *handle, LSM6DS3_ACC_GYRO_SIGN_MOT_EV_STATUS_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_SIGN_MOT_EV_STATUS(void *handle, LSM6DS3_ACC_GYRO_SIGN_MOT_EV_STATUS_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_FUNC_SRC, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -4708,7 +4708,7 @@ status_t LSM6DS3_ACC_GYRO_R_SIGN_MOT_EV_STATUS(void *handle, LSM6DS3_ACC_GYRO_SI
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM6DS3_ACC_GYRO_W_LIR(void *handle, LSM6DS3_ACC_GYRO_LIR_t newValue)
+mems_status_t  LSM6DS3_ACC_GYRO_W_LIR(void *handle, LSM6DS3_ACC_GYRO_LIR_t newValue)
 {
   u8_t value;
 
@@ -4731,7 +4731,7 @@ status_t  LSM6DS3_ACC_GYRO_W_LIR(void *handle, LSM6DS3_ACC_GYRO_LIR_t newValue)
 * Output         : Status of LIR see LSM6DS3_ACC_GYRO_LIR_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_LIR(void *handle, LSM6DS3_ACC_GYRO_LIR_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_LIR(void *handle, LSM6DS3_ACC_GYRO_LIR_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_TAP_CFG1, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -4748,7 +4748,7 @@ status_t LSM6DS3_ACC_GYRO_R_LIR(void *handle, LSM6DS3_ACC_GYRO_LIR_t *value)
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM6DS3_ACC_GYRO_W_TAP_Z_EN(void *handle, LSM6DS3_ACC_GYRO_TAP_Z_EN_t newValue)
+mems_status_t  LSM6DS3_ACC_GYRO_W_TAP_Z_EN(void *handle, LSM6DS3_ACC_GYRO_TAP_Z_EN_t newValue)
 {
   u8_t value;
 
@@ -4771,7 +4771,7 @@ status_t  LSM6DS3_ACC_GYRO_W_TAP_Z_EN(void *handle, LSM6DS3_ACC_GYRO_TAP_Z_EN_t 
 * Output         : Status of TAP_Z_EN see LSM6DS3_ACC_GYRO_TAP_Z_EN_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_TAP_Z_EN(void *handle, LSM6DS3_ACC_GYRO_TAP_Z_EN_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_TAP_Z_EN(void *handle, LSM6DS3_ACC_GYRO_TAP_Z_EN_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_TAP_CFG1, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -4788,7 +4788,7 @@ status_t LSM6DS3_ACC_GYRO_R_TAP_Z_EN(void *handle, LSM6DS3_ACC_GYRO_TAP_Z_EN_t *
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM6DS3_ACC_GYRO_W_TAP_Y_EN(void *handle, LSM6DS3_ACC_GYRO_TAP_Y_EN_t newValue)
+mems_status_t  LSM6DS3_ACC_GYRO_W_TAP_Y_EN(void *handle, LSM6DS3_ACC_GYRO_TAP_Y_EN_t newValue)
 {
   u8_t value;
 
@@ -4811,7 +4811,7 @@ status_t  LSM6DS3_ACC_GYRO_W_TAP_Y_EN(void *handle, LSM6DS3_ACC_GYRO_TAP_Y_EN_t 
 * Output         : Status of TAP_Y_EN see LSM6DS3_ACC_GYRO_TAP_Y_EN_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_TAP_Y_EN(void *handle, LSM6DS3_ACC_GYRO_TAP_Y_EN_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_TAP_Y_EN(void *handle, LSM6DS3_ACC_GYRO_TAP_Y_EN_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_TAP_CFG1, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -4828,7 +4828,7 @@ status_t LSM6DS3_ACC_GYRO_R_TAP_Y_EN(void *handle, LSM6DS3_ACC_GYRO_TAP_Y_EN_t *
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM6DS3_ACC_GYRO_W_TAP_X_EN(void *handle, LSM6DS3_ACC_GYRO_TAP_X_EN_t newValue)
+mems_status_t  LSM6DS3_ACC_GYRO_W_TAP_X_EN(void *handle, LSM6DS3_ACC_GYRO_TAP_X_EN_t newValue)
 {
   u8_t value;
 
@@ -4851,7 +4851,7 @@ status_t  LSM6DS3_ACC_GYRO_W_TAP_X_EN(void *handle, LSM6DS3_ACC_GYRO_TAP_X_EN_t 
 * Output         : Status of TAP_X_EN see LSM6DS3_ACC_GYRO_TAP_X_EN_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_TAP_X_EN(void *handle, LSM6DS3_ACC_GYRO_TAP_X_EN_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_TAP_X_EN(void *handle, LSM6DS3_ACC_GYRO_TAP_X_EN_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_TAP_CFG1, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -4868,7 +4868,7 @@ status_t LSM6DS3_ACC_GYRO_R_TAP_X_EN(void *handle, LSM6DS3_ACC_GYRO_TAP_X_EN_t *
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM6DS3_ACC_GYRO_W_TILT_EN(void *handle, LSM6DS3_ACC_GYRO_TILT_EN_t newValue)
+mems_status_t  LSM6DS3_ACC_GYRO_W_TILT_EN(void *handle, LSM6DS3_ACC_GYRO_TILT_EN_t newValue)
 {
   u8_t value;
 
@@ -4891,7 +4891,7 @@ status_t  LSM6DS3_ACC_GYRO_W_TILT_EN(void *handle, LSM6DS3_ACC_GYRO_TILT_EN_t ne
 * Output         : Status of TILT_EN see LSM6DS3_ACC_GYRO_TILT_EN_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_TILT_EN(void *handle, LSM6DS3_ACC_GYRO_TILT_EN_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_TILT_EN(void *handle, LSM6DS3_ACC_GYRO_TILT_EN_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_TAP_CFG1, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -4908,7 +4908,7 @@ status_t LSM6DS3_ACC_GYRO_R_TILT_EN(void *handle, LSM6DS3_ACC_GYRO_TILT_EN_t *va
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM6DS3_ACC_GYRO_W_SLOPE_FDS(void *handle, LSM6DS3_ACC_GYRO_SLOPE_FDS_t newValue)
+mems_status_t  LSM6DS3_ACC_GYRO_W_SLOPE_FDS(void *handle, LSM6DS3_ACC_GYRO_SLOPE_FDS_t newValue)
 {
   u8_t value;
 
@@ -4931,7 +4931,7 @@ status_t  LSM6DS3_ACC_GYRO_W_SLOPE_FDS(void *handle, LSM6DS3_ACC_GYRO_SLOPE_FDS_
 * Output         : Status of SLOPE_FDS see LSM6DS3_ACC_GYRO_SLOPE_FDS_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_SLOPE_FDS(void *handle, LSM6DS3_ACC_GYRO_SLOPE_FDS_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_SLOPE_FDS(void *handle, LSM6DS3_ACC_GYRO_SLOPE_FDS_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_TAP_CFG1, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -4948,7 +4948,7 @@ status_t LSM6DS3_ACC_GYRO_R_SLOPE_FDS(void *handle, LSM6DS3_ACC_GYRO_SLOPE_FDS_t
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM6DS3_ACC_GYRO_W_PEDO_EN(void *handle, LSM6DS3_ACC_GYRO_PEDO_EN_t newValue)
+mems_status_t  LSM6DS3_ACC_GYRO_W_PEDO_EN(void *handle, LSM6DS3_ACC_GYRO_PEDO_EN_t newValue)
 {
   u8_t value;
 
@@ -4971,7 +4971,7 @@ status_t  LSM6DS3_ACC_GYRO_W_PEDO_EN(void *handle, LSM6DS3_ACC_GYRO_PEDO_EN_t ne
 * Output         : Status of PEDO_EN see LSM6DS3_ACC_GYRO_PEDO_EN_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_PEDO_EN(void *handle, LSM6DS3_ACC_GYRO_PEDO_EN_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_PEDO_EN(void *handle, LSM6DS3_ACC_GYRO_PEDO_EN_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_TAP_CFG1, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -4988,7 +4988,7 @@ status_t LSM6DS3_ACC_GYRO_R_PEDO_EN(void *handle, LSM6DS3_ACC_GYRO_PEDO_EN_t *va
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM6DS3_ACC_GYRO_W_TIMER_EN(void *handle, LSM6DS3_ACC_GYRO_TIMER_EN_t newValue)
+mems_status_t  LSM6DS3_ACC_GYRO_W_TIMER_EN(void *handle, LSM6DS3_ACC_GYRO_TIMER_EN_t newValue)
 {
   u8_t value;
 
@@ -5011,7 +5011,7 @@ status_t  LSM6DS3_ACC_GYRO_W_TIMER_EN(void *handle, LSM6DS3_ACC_GYRO_TIMER_EN_t 
 * Output         : Status of TIMER_EN see LSM6DS3_ACC_GYRO_TIMER_EN_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_TIMER_EN(void *handle, LSM6DS3_ACC_GYRO_TIMER_EN_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_TIMER_EN(void *handle, LSM6DS3_ACC_GYRO_TIMER_EN_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_TAP_CFG1, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -5028,7 +5028,7 @@ status_t LSM6DS3_ACC_GYRO_R_TIMER_EN(void *handle, LSM6DS3_ACC_GYRO_TIMER_EN_t *
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM6DS3_ACC_GYRO_W_TAP_THS(void *handle, u8_t newValue)
+mems_status_t  LSM6DS3_ACC_GYRO_W_TAP_THS(void *handle, u8_t newValue)
 {
   u8_t value;
 
@@ -5054,7 +5054,7 @@ status_t  LSM6DS3_ACC_GYRO_W_TAP_THS(void *handle, u8_t newValue)
 * Output         : Status of TAP_THS
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_TAP_THS(void *handle, u8_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_TAP_THS(void *handle, u8_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_TAP_THS_6D, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -5072,7 +5072,7 @@ status_t LSM6DS3_ACC_GYRO_R_TAP_THS(void *handle, u8_t *value)
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM6DS3_ACC_GYRO_W_SIXD_THS(void *handle, LSM6DS3_ACC_GYRO_SIXD_THS_t newValue)
+mems_status_t  LSM6DS3_ACC_GYRO_W_SIXD_THS(void *handle, LSM6DS3_ACC_GYRO_SIXD_THS_t newValue)
 {
   u8_t value;
 
@@ -5095,7 +5095,7 @@ status_t  LSM6DS3_ACC_GYRO_W_SIXD_THS(void *handle, LSM6DS3_ACC_GYRO_SIXD_THS_t 
 * Output         : Status of SIXD_THS see LSM6DS3_ACC_GYRO_SIXD_THS_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_SIXD_THS(void *handle, LSM6DS3_ACC_GYRO_SIXD_THS_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_SIXD_THS(void *handle, LSM6DS3_ACC_GYRO_SIXD_THS_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_TAP_THS_6D, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -5112,7 +5112,7 @@ status_t LSM6DS3_ACC_GYRO_R_SIXD_THS(void *handle, LSM6DS3_ACC_GYRO_SIXD_THS_t *
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM6DS3_ACC_GYRO_W_D4D(void *handle, LSM6DS3_ACC_GYRO_D4D_t newValue)
+mems_status_t  LSM6DS3_ACC_GYRO_W_D4D(void *handle, LSM6DS3_ACC_GYRO_D4D_t newValue)
 {
   u8_t value;
 
@@ -5135,7 +5135,7 @@ status_t  LSM6DS3_ACC_GYRO_W_D4D(void *handle, LSM6DS3_ACC_GYRO_D4D_t newValue)
 * Output         : Status of D4D_EN see LSM6DS3_ACC_GYRO_D4D_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_D4D(void *handle, LSM6DS3_ACC_GYRO_D4D_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_D4D(void *handle, LSM6DS3_ACC_GYRO_D4D_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_TAP_THS_6D, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -5152,7 +5152,7 @@ status_t LSM6DS3_ACC_GYRO_R_D4D(void *handle, LSM6DS3_ACC_GYRO_D4D_t *value)
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM6DS3_ACC_GYRO_W_SHOCK_Duration(void *handle, u8_t newValue)
+mems_status_t  LSM6DS3_ACC_GYRO_W_SHOCK_Duration(void *handle, u8_t newValue)
 {
   u8_t value;
 
@@ -5178,7 +5178,7 @@ status_t  LSM6DS3_ACC_GYRO_W_SHOCK_Duration(void *handle, u8_t newValue)
 * Output         : Status of SHOCK
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_SHOCK_Duration(void *handle, u8_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_SHOCK_Duration(void *handle, u8_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_INT_DUR2, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -5196,7 +5196,7 @@ status_t LSM6DS3_ACC_GYRO_R_SHOCK_Duration(void *handle, u8_t *value)
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM6DS3_ACC_GYRO_W_QUIET_Duration(void *handle, u8_t newValue)
+mems_status_t  LSM6DS3_ACC_GYRO_W_QUIET_Duration(void *handle, u8_t newValue)
 {
   u8_t value;
 
@@ -5222,7 +5222,7 @@ status_t  LSM6DS3_ACC_GYRO_W_QUIET_Duration(void *handle, u8_t newValue)
 * Output         : Status of QUIET
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_QUIET_Duration(void *handle, u8_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_QUIET_Duration(void *handle, u8_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_INT_DUR2, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -5240,7 +5240,7 @@ status_t LSM6DS3_ACC_GYRO_R_QUIET_Duration(void *handle, u8_t *value)
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM6DS3_ACC_GYRO_W_DUR(void *handle, u8_t newValue)
+mems_status_t  LSM6DS3_ACC_GYRO_W_DUR(void *handle, u8_t newValue)
 {
   u8_t value;
 
@@ -5266,7 +5266,7 @@ status_t  LSM6DS3_ACC_GYRO_W_DUR(void *handle, u8_t newValue)
 * Output         : Status of DUR
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_DUR(void *handle, u8_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_DUR(void *handle, u8_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_INT_DUR2, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -5284,7 +5284,7 @@ status_t LSM6DS3_ACC_GYRO_R_DUR(void *handle, u8_t *value)
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM6DS3_ACC_GYRO_W_WK_THS(void *handle, u8_t newValue)
+mems_status_t  LSM6DS3_ACC_GYRO_W_WK_THS(void *handle, u8_t newValue)
 {
   u8_t value;
 
@@ -5310,7 +5310,7 @@ status_t  LSM6DS3_ACC_GYRO_W_WK_THS(void *handle, u8_t newValue)
 * Output         : Status of WK_THS
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_WK_THS(void *handle, u8_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_WK_THS(void *handle, u8_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_WAKE_UP_THS, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -5328,7 +5328,7 @@ status_t LSM6DS3_ACC_GYRO_R_WK_THS(void *handle, u8_t *value)
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM6DS3_ACC_GYRO_W_INACTIVITY_ON(void *handle, LSM6DS3_ACC_GYRO_INACTIVITY_ON_t newValue)
+mems_status_t  LSM6DS3_ACC_GYRO_W_INACTIVITY_ON(void *handle, LSM6DS3_ACC_GYRO_INACTIVITY_ON_t newValue)
 {
   u8_t value;
 
@@ -5351,7 +5351,7 @@ status_t  LSM6DS3_ACC_GYRO_W_INACTIVITY_ON(void *handle, LSM6DS3_ACC_GYRO_INACTI
 * Output         : Status of INACTIVITY_ON see LSM6DS3_ACC_GYRO_INACTIVITY_ON_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_INACTIVITY_ON(void *handle, LSM6DS3_ACC_GYRO_INACTIVITY_ON_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_INACTIVITY_ON(void *handle, LSM6DS3_ACC_GYRO_INACTIVITY_ON_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_WAKE_UP_THS, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -5368,7 +5368,7 @@ status_t LSM6DS3_ACC_GYRO_R_INACTIVITY_ON(void *handle, LSM6DS3_ACC_GYRO_INACTIV
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM6DS3_ACC_GYRO_W_SINGLE_DOUBLE_TAP_EV(void *handle, LSM6DS3_ACC_GYRO_SINGLE_DOUBLE_TAP_t newValue)
+mems_status_t  LSM6DS3_ACC_GYRO_W_SINGLE_DOUBLE_TAP_EV(void *handle, LSM6DS3_ACC_GYRO_SINGLE_DOUBLE_TAP_t newValue)
 {
   u8_t value;
 
@@ -5391,7 +5391,7 @@ status_t  LSM6DS3_ACC_GYRO_W_SINGLE_DOUBLE_TAP_EV(void *handle, LSM6DS3_ACC_GYRO
 * Output         : Status of SINGLE_DOUBLE_TAP see LSM6DS3_ACC_GYRO_SINGLE_DOUBLE_TAP_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_SINGLE_DOUBLE_TAP_EV(void *handle, LSM6DS3_ACC_GYRO_SINGLE_DOUBLE_TAP_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_SINGLE_DOUBLE_TAP_EV(void *handle, LSM6DS3_ACC_GYRO_SINGLE_DOUBLE_TAP_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_WAKE_UP_THS, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -5408,7 +5408,7 @@ status_t LSM6DS3_ACC_GYRO_R_SINGLE_DOUBLE_TAP_EV(void *handle, LSM6DS3_ACC_GYRO_
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM6DS3_ACC_GYRO_W_SLEEP_DUR(void *handle, u8_t newValue)
+mems_status_t  LSM6DS3_ACC_GYRO_W_SLEEP_DUR(void *handle, u8_t newValue)
 {
   u8_t value;
 
@@ -5434,7 +5434,7 @@ status_t  LSM6DS3_ACC_GYRO_W_SLEEP_DUR(void *handle, u8_t newValue)
 * Output         : Status of SLEEP_DUR
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_SLEEP_DUR(void *handle, u8_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_SLEEP_DUR(void *handle, u8_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_WAKE_UP_DUR, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -5452,7 +5452,7 @@ status_t LSM6DS3_ACC_GYRO_R_SLEEP_DUR(void *handle, u8_t *value)
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM6DS3_ACC_GYRO_W_TIMER_HR(void *handle, LSM6DS3_ACC_GYRO_TIMER_HR_t newValue)
+mems_status_t  LSM6DS3_ACC_GYRO_W_TIMER_HR(void *handle, LSM6DS3_ACC_GYRO_TIMER_HR_t newValue)
 {
   u8_t value;
 
@@ -5475,7 +5475,7 @@ status_t  LSM6DS3_ACC_GYRO_W_TIMER_HR(void *handle, LSM6DS3_ACC_GYRO_TIMER_HR_t 
 * Output         : Status of TIMER_HR see LSM6DS3_ACC_GYRO_TIMER_HR_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_TIMER_HR(void *handle, LSM6DS3_ACC_GYRO_TIMER_HR_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_TIMER_HR(void *handle, LSM6DS3_ACC_GYRO_TIMER_HR_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_WAKE_UP_DUR, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -5492,7 +5492,7 @@ status_t LSM6DS3_ACC_GYRO_R_TIMER_HR(void *handle, LSM6DS3_ACC_GYRO_TIMER_HR_t *
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM6DS3_ACC_GYRO_W_WAKE_DUR(void *handle, u8_t newValue)
+mems_status_t  LSM6DS3_ACC_GYRO_W_WAKE_DUR(void *handle, u8_t newValue)
 {
   u8_t value;
 
@@ -5518,7 +5518,7 @@ status_t  LSM6DS3_ACC_GYRO_W_WAKE_DUR(void *handle, u8_t newValue)
 * Output         : Status of WAKE_DUR
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_WAKE_DUR(void *handle, u8_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_WAKE_DUR(void *handle, u8_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_WAKE_UP_DUR, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -5536,7 +5536,7 @@ status_t LSM6DS3_ACC_GYRO_R_WAKE_DUR(void *handle, u8_t *value)
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM6DS3_ACC_GYRO_W_FF_THS(void *handle, LSM6DS3_ACC_GYRO_FF_THS_t newValue)
+mems_status_t  LSM6DS3_ACC_GYRO_W_FF_THS(void *handle, LSM6DS3_ACC_GYRO_FF_THS_t newValue)
 {
   u8_t value;
 
@@ -5559,7 +5559,7 @@ status_t  LSM6DS3_ACC_GYRO_W_FF_THS(void *handle, LSM6DS3_ACC_GYRO_FF_THS_t newV
 * Output         : Status of FF_THS see LSM6DS3_ACC_GYRO_FF_THS_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_FF_THS(void *handle, LSM6DS3_ACC_GYRO_FF_THS_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_FF_THS(void *handle, LSM6DS3_ACC_GYRO_FF_THS_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_FREE_FALL, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -5576,7 +5576,7 @@ status_t LSM6DS3_ACC_GYRO_R_FF_THS(void *handle, LSM6DS3_ACC_GYRO_FF_THS_t *valu
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM6DS3_ACC_GYRO_W_FF_Duration(void *handle, u8_t newValue)
+mems_status_t  LSM6DS3_ACC_GYRO_W_FF_Duration(void *handle, u8_t newValue)
 {
   u8_t valueH, valueL;
   u8_t value;
@@ -5620,7 +5620,7 @@ status_t  LSM6DS3_ACC_GYRO_W_FF_Duration(void *handle, u8_t newValue)
 * Output         : Status of FF_DUR
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_FF_Duration(void *handle, u8_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_FF_Duration(void *handle, u8_t *value)
 {
   u8_t valueH, valueL;
 
@@ -5650,7 +5650,7 @@ status_t LSM6DS3_ACC_GYRO_R_FF_Duration(void *handle, u8_t *value)
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM6DS3_ACC_GYRO_W_TimerEvRouteInt1(void *handle, LSM6DS3_ACC_GYRO_INT1_TIMER_t newValue)
+mems_status_t  LSM6DS3_ACC_GYRO_W_TimerEvRouteInt1(void *handle, LSM6DS3_ACC_GYRO_INT1_TIMER_t newValue)
 {
   u8_t value;
 
@@ -5673,7 +5673,7 @@ status_t  LSM6DS3_ACC_GYRO_W_TimerEvRouteInt1(void *handle, LSM6DS3_ACC_GYRO_INT
 * Output         : Status of INT1_TIMER see LSM6DS3_ACC_GYRO_INT1_TIMER_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_TimerEvRouteInt1(void *handle, LSM6DS3_ACC_GYRO_INT1_TIMER_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_TimerEvRouteInt1(void *handle, LSM6DS3_ACC_GYRO_INT1_TIMER_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_MD1_CFG, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -5690,7 +5690,7 @@ status_t LSM6DS3_ACC_GYRO_R_TimerEvRouteInt1(void *handle, LSM6DS3_ACC_GYRO_INT1
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM6DS3_ACC_GYRO_W_TiltEvOnInt1(void *handle, LSM6DS3_ACC_GYRO_INT1_TILT_t newValue)
+mems_status_t  LSM6DS3_ACC_GYRO_W_TiltEvOnInt1(void *handle, LSM6DS3_ACC_GYRO_INT1_TILT_t newValue)
 {
   u8_t value;
 
@@ -5713,7 +5713,7 @@ status_t  LSM6DS3_ACC_GYRO_W_TiltEvOnInt1(void *handle, LSM6DS3_ACC_GYRO_INT1_TI
 * Output         : Status of INT1_TILT see LSM6DS3_ACC_GYRO_INT1_TILT_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_TiltEvOnInt1(void *handle, LSM6DS3_ACC_GYRO_INT1_TILT_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_TiltEvOnInt1(void *handle, LSM6DS3_ACC_GYRO_INT1_TILT_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_MD1_CFG, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -5730,7 +5730,7 @@ status_t LSM6DS3_ACC_GYRO_R_TiltEvOnInt1(void *handle, LSM6DS3_ACC_GYRO_INT1_TIL
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM6DS3_ACC_GYRO_W_6DEvOnInt1(void *handle, LSM6DS3_ACC_GYRO_INT1_6D_t newValue)
+mems_status_t  LSM6DS3_ACC_GYRO_W_6DEvOnInt1(void *handle, LSM6DS3_ACC_GYRO_INT1_6D_t newValue)
 {
   u8_t value;
 
@@ -5753,7 +5753,7 @@ status_t  LSM6DS3_ACC_GYRO_W_6DEvOnInt1(void *handle, LSM6DS3_ACC_GYRO_INT1_6D_t
 * Output         : Status of INT1_6D see LSM6DS3_ACC_GYRO_INT1_6D_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_6DEvOnInt1(void *handle, LSM6DS3_ACC_GYRO_INT1_6D_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_6DEvOnInt1(void *handle, LSM6DS3_ACC_GYRO_INT1_6D_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_MD1_CFG, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -5770,7 +5770,7 @@ status_t LSM6DS3_ACC_GYRO_R_6DEvOnInt1(void *handle, LSM6DS3_ACC_GYRO_INT1_6D_t 
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM6DS3_ACC_GYRO_W_TapEvOnInt1(void *handle, LSM6DS3_ACC_GYRO_INT1_TAP_t newValue)
+mems_status_t  LSM6DS3_ACC_GYRO_W_TapEvOnInt1(void *handle, LSM6DS3_ACC_GYRO_INT1_TAP_t newValue)
 {
   u8_t value;
 
@@ -5793,7 +5793,7 @@ status_t  LSM6DS3_ACC_GYRO_W_TapEvOnInt1(void *handle, LSM6DS3_ACC_GYRO_INT1_TAP
 * Output         : Status of INT1_TAP see LSM6DS3_ACC_GYRO_INT1_TAP_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_TapEvOnInt1(void *handle, LSM6DS3_ACC_GYRO_INT1_TAP_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_TapEvOnInt1(void *handle, LSM6DS3_ACC_GYRO_INT1_TAP_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_MD1_CFG, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -5810,7 +5810,7 @@ status_t LSM6DS3_ACC_GYRO_R_TapEvOnInt1(void *handle, LSM6DS3_ACC_GYRO_INT1_TAP_
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM6DS3_ACC_GYRO_W_FFEvOnInt1(void *handle, LSM6DS3_ACC_GYRO_INT1_FF_t newValue)
+mems_status_t  LSM6DS3_ACC_GYRO_W_FFEvOnInt1(void *handle, LSM6DS3_ACC_GYRO_INT1_FF_t newValue)
 {
   u8_t value;
 
@@ -5833,7 +5833,7 @@ status_t  LSM6DS3_ACC_GYRO_W_FFEvOnInt1(void *handle, LSM6DS3_ACC_GYRO_INT1_FF_t
 * Output         : Status of INT1_FF see LSM6DS3_ACC_GYRO_INT1_FF_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_FFEvOnInt1(void *handle, LSM6DS3_ACC_GYRO_INT1_FF_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_FFEvOnInt1(void *handle, LSM6DS3_ACC_GYRO_INT1_FF_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_MD1_CFG, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -5850,7 +5850,7 @@ status_t LSM6DS3_ACC_GYRO_R_FFEvOnInt1(void *handle, LSM6DS3_ACC_GYRO_INT1_FF_t 
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM6DS3_ACC_GYRO_W_WUEvOnInt1(void *handle, LSM6DS3_ACC_GYRO_INT1_WU_t newValue)
+mems_status_t  LSM6DS3_ACC_GYRO_W_WUEvOnInt1(void *handle, LSM6DS3_ACC_GYRO_INT1_WU_t newValue)
 {
   u8_t value;
 
@@ -5873,7 +5873,7 @@ status_t  LSM6DS3_ACC_GYRO_W_WUEvOnInt1(void *handle, LSM6DS3_ACC_GYRO_INT1_WU_t
 * Output         : Status of INT1_WU see LSM6DS3_ACC_GYRO_INT1_WU_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_WUEvOnInt1(void *handle, LSM6DS3_ACC_GYRO_INT1_WU_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_WUEvOnInt1(void *handle, LSM6DS3_ACC_GYRO_INT1_WU_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_MD1_CFG, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -5890,7 +5890,7 @@ status_t LSM6DS3_ACC_GYRO_R_WUEvOnInt1(void *handle, LSM6DS3_ACC_GYRO_INT1_WU_t 
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM6DS3_ACC_GYRO_W_SingleTapOnInt1(void *handle, LSM6DS3_ACC_GYRO_INT1_SINGLE_TAP_t newValue)
+mems_status_t  LSM6DS3_ACC_GYRO_W_SingleTapOnInt1(void *handle, LSM6DS3_ACC_GYRO_INT1_SINGLE_TAP_t newValue)
 {
   u8_t value;
 
@@ -5913,7 +5913,7 @@ status_t  LSM6DS3_ACC_GYRO_W_SingleTapOnInt1(void *handle, LSM6DS3_ACC_GYRO_INT1
 * Output         : Status of INT1_SINGLE_TAP see LSM6DS3_ACC_GYRO_INT1_SINGLE_TAP_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_SingleTapOnInt1(void *handle, LSM6DS3_ACC_GYRO_INT1_SINGLE_TAP_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_SingleTapOnInt1(void *handle, LSM6DS3_ACC_GYRO_INT1_SINGLE_TAP_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_MD1_CFG, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -5930,7 +5930,7 @@ status_t LSM6DS3_ACC_GYRO_R_SingleTapOnInt1(void *handle, LSM6DS3_ACC_GYRO_INT1_
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM6DS3_ACC_GYRO_W_SleepEvOnInt1(void *handle, LSM6DS3_ACC_GYRO_INT1_SLEEP_t newValue)
+mems_status_t  LSM6DS3_ACC_GYRO_W_SleepEvOnInt1(void *handle, LSM6DS3_ACC_GYRO_INT1_SLEEP_t newValue)
 {
   u8_t value;
 
@@ -5953,7 +5953,7 @@ status_t  LSM6DS3_ACC_GYRO_W_SleepEvOnInt1(void *handle, LSM6DS3_ACC_GYRO_INT1_S
 * Output         : Status of INT1_SLEEP see LSM6DS3_ACC_GYRO_INT1_SLEEP_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_SleepEvOnInt1(void *handle, LSM6DS3_ACC_GYRO_INT1_SLEEP_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_SleepEvOnInt1(void *handle, LSM6DS3_ACC_GYRO_INT1_SLEEP_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_MD1_CFG, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -5970,7 +5970,7 @@ status_t LSM6DS3_ACC_GYRO_R_SleepEvOnInt1(void *handle, LSM6DS3_ACC_GYRO_INT1_SL
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM6DS3_ACC_GYRO_W_TimerEvRouteInt2(void *handle, LSM6DS3_ACC_GYRO_INT2_TIMER_t newValue)
+mems_status_t  LSM6DS3_ACC_GYRO_W_TimerEvRouteInt2(void *handle, LSM6DS3_ACC_GYRO_INT2_TIMER_t newValue)
 {
   u8_t value;
 
@@ -5993,7 +5993,7 @@ status_t  LSM6DS3_ACC_GYRO_W_TimerEvRouteInt2(void *handle, LSM6DS3_ACC_GYRO_INT
 * Output         : Status of INT2_TIMER see LSM6DS3_ACC_GYRO_INT2_TIMER_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_TimerEvRouteInt2(void *handle, LSM6DS3_ACC_GYRO_INT2_TIMER_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_TimerEvRouteInt2(void *handle, LSM6DS3_ACC_GYRO_INT2_TIMER_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_MD2_CFG, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -6010,7 +6010,7 @@ status_t LSM6DS3_ACC_GYRO_R_TimerEvRouteInt2(void *handle, LSM6DS3_ACC_GYRO_INT2
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM6DS3_ACC_GYRO_W_TiltEvOnInt2(void *handle, LSM6DS3_ACC_GYRO_INT2_TILT_t newValue)
+mems_status_t  LSM6DS3_ACC_GYRO_W_TiltEvOnInt2(void *handle, LSM6DS3_ACC_GYRO_INT2_TILT_t newValue)
 {
   u8_t value;
 
@@ -6033,7 +6033,7 @@ status_t  LSM6DS3_ACC_GYRO_W_TiltEvOnInt2(void *handle, LSM6DS3_ACC_GYRO_INT2_TI
 * Output         : Status of INT2_TILT see LSM6DS3_ACC_GYRO_INT2_TILT_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_TiltEvOnInt2(void *handle, LSM6DS3_ACC_GYRO_INT2_TILT_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_TiltEvOnInt2(void *handle, LSM6DS3_ACC_GYRO_INT2_TILT_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_MD2_CFG, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -6050,7 +6050,7 @@ status_t LSM6DS3_ACC_GYRO_R_TiltEvOnInt2(void *handle, LSM6DS3_ACC_GYRO_INT2_TIL
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM6DS3_ACC_GYRO_W_6DEvOnInt2(void *handle, LSM6DS3_ACC_GYRO_INT2_6D_t newValue)
+mems_status_t  LSM6DS3_ACC_GYRO_W_6DEvOnInt2(void *handle, LSM6DS3_ACC_GYRO_INT2_6D_t newValue)
 {
   u8_t value;
 
@@ -6073,7 +6073,7 @@ status_t  LSM6DS3_ACC_GYRO_W_6DEvOnInt2(void *handle, LSM6DS3_ACC_GYRO_INT2_6D_t
 * Output         : Status of INT2_6D see LSM6DS3_ACC_GYRO_INT2_6D_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_6DEvOnInt2(void *handle, LSM6DS3_ACC_GYRO_INT2_6D_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_6DEvOnInt2(void *handle, LSM6DS3_ACC_GYRO_INT2_6D_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_MD2_CFG, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -6089,7 +6089,7 @@ status_t LSM6DS3_ACC_GYRO_R_6DEvOnInt2(void *handle, LSM6DS3_ACC_GYRO_INT2_6D_t 
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM6DS3_ACC_GYRO_W_TapEvOnInt2(void *handle, LSM6DS3_ACC_GYRO_INT2_TAP_t newValue)
+mems_status_t  LSM6DS3_ACC_GYRO_W_TapEvOnInt2(void *handle, LSM6DS3_ACC_GYRO_INT2_TAP_t newValue)
 {
   u8_t value;
 
@@ -6112,7 +6112,7 @@ status_t  LSM6DS3_ACC_GYRO_W_TapEvOnInt2(void *handle, LSM6DS3_ACC_GYRO_INT2_TAP
 * Output         : Status of INT2_TAP see LSM6DS3_ACC_GYRO_INT2_TAP_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_TapEvOnInt2(void *handle, LSM6DS3_ACC_GYRO_INT2_TAP_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_TapEvOnInt2(void *handle, LSM6DS3_ACC_GYRO_INT2_TAP_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_MD2_CFG, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -6129,7 +6129,7 @@ status_t LSM6DS3_ACC_GYRO_R_TapEvOnInt2(void *handle, LSM6DS3_ACC_GYRO_INT2_TAP_
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM6DS3_ACC_GYRO_W_FFEvOnInt2(void *handle, LSM6DS3_ACC_GYRO_INT2_FF_t newValue)
+mems_status_t  LSM6DS3_ACC_GYRO_W_FFEvOnInt2(void *handle, LSM6DS3_ACC_GYRO_INT2_FF_t newValue)
 {
   u8_t value;
 
@@ -6152,7 +6152,7 @@ status_t  LSM6DS3_ACC_GYRO_W_FFEvOnInt2(void *handle, LSM6DS3_ACC_GYRO_INT2_FF_t
 * Output         : Status of INT2_FF see LSM6DS3_ACC_GYRO_INT2_FF_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_FFEvOnInt2(void *handle, LSM6DS3_ACC_GYRO_INT2_FF_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_FFEvOnInt2(void *handle, LSM6DS3_ACC_GYRO_INT2_FF_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_MD2_CFG, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -6169,7 +6169,7 @@ status_t LSM6DS3_ACC_GYRO_R_FFEvOnInt2(void *handle, LSM6DS3_ACC_GYRO_INT2_FF_t 
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM6DS3_ACC_GYRO_W_WUEvOnInt2(void *handle, LSM6DS3_ACC_GYRO_INT2_WU_t newValue)
+mems_status_t  LSM6DS3_ACC_GYRO_W_WUEvOnInt2(void *handle, LSM6DS3_ACC_GYRO_INT2_WU_t newValue)
 {
   u8_t value;
 
@@ -6192,7 +6192,7 @@ status_t  LSM6DS3_ACC_GYRO_W_WUEvOnInt2(void *handle, LSM6DS3_ACC_GYRO_INT2_WU_t
 * Output         : Status of INT2_WU see LSM6DS3_ACC_GYRO_INT2_WU_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_WUEvOnInt2(void *handle, LSM6DS3_ACC_GYRO_INT2_WU_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_WUEvOnInt2(void *handle, LSM6DS3_ACC_GYRO_INT2_WU_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_MD2_CFG, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -6209,7 +6209,7 @@ status_t LSM6DS3_ACC_GYRO_R_WUEvOnInt2(void *handle, LSM6DS3_ACC_GYRO_INT2_WU_t 
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM6DS3_ACC_GYRO_W_SingleTapOnInt2(void *handle, LSM6DS3_ACC_GYRO_INT2_SINGLE_TAP_t newValue)
+mems_status_t  LSM6DS3_ACC_GYRO_W_SingleTapOnInt2(void *handle, LSM6DS3_ACC_GYRO_INT2_SINGLE_TAP_t newValue)
 {
   u8_t value;
 
@@ -6232,7 +6232,7 @@ status_t  LSM6DS3_ACC_GYRO_W_SingleTapOnInt2(void *handle, LSM6DS3_ACC_GYRO_INT2
 * Output         : Status of INT2_SINGLE_TAP see LSM6DS3_ACC_GYRO_INT2_SINGLE_TAP_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_SingleTapOnInt2(void *handle, LSM6DS3_ACC_GYRO_INT2_SINGLE_TAP_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_SingleTapOnInt2(void *handle, LSM6DS3_ACC_GYRO_INT2_SINGLE_TAP_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_MD2_CFG, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -6249,7 +6249,7 @@ status_t LSM6DS3_ACC_GYRO_R_SingleTapOnInt2(void *handle, LSM6DS3_ACC_GYRO_INT2_
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM6DS3_ACC_GYRO_W_SleepEvOnInt2(void *handle, LSM6DS3_ACC_GYRO_INT2_SLEEP_t newValue)
+mems_status_t  LSM6DS3_ACC_GYRO_W_SleepEvOnInt2(void *handle, LSM6DS3_ACC_GYRO_INT2_SLEEP_t newValue)
 {
   u8_t value;
 
@@ -6272,7 +6272,7 @@ status_t  LSM6DS3_ACC_GYRO_W_SleepEvOnInt2(void *handle, LSM6DS3_ACC_GYRO_INT2_S
 * Output         : Status of INT2_SLEEP see LSM6DS3_ACC_GYRO_INT2_SLEEP_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_R_SleepEvOnInt2(void *handle, LSM6DS3_ACC_GYRO_INT2_SLEEP_t *value)
+mems_status_t LSM6DS3_ACC_GYRO_R_SleepEvOnInt2(void *handle, LSM6DS3_ACC_GYRO_INT2_SLEEP_t *value)
 {
   if( !LSM6DS3_ACC_GYRO_ReadReg(handle, LSM6DS3_ACC_GYRO_MD2_CFG, (u8_t *)value, 1) )
     return MEMS_ERROR;
@@ -6283,13 +6283,13 @@ status_t LSM6DS3_ACC_GYRO_R_SleepEvOnInt2(void *handle, LSM6DS3_ACC_GYRO_INT2_SL
 }
 
 /*******************************************************************************
-* Function Name  : status_t LSM6DS3_ACC_GYRO_Get_GetFIFOData(u8_t *buff)
+* Function Name  : mems_status_t LSM6DS3_ACC_GYRO_Get_GetFIFOData(u8_t *buff)
 * Description    : Read GetFIFOData output register
 * Input          : pointer to [u8_t]
 * Output         : GetFIFOData buffer u8_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_Get_GetFIFOData(void *handle, u8_t *buff)
+mems_status_t LSM6DS3_ACC_GYRO_Get_GetFIFOData(void *handle, u8_t *buff)
 {
   u8_t i, j, k;
   u8_t numberOfByteForDimension;
@@ -6311,13 +6311,13 @@ status_t LSM6DS3_ACC_GYRO_Get_GetFIFOData(void *handle, u8_t *buff)
 }
 
 /*******************************************************************************
-* Function Name  : status_t LSM6DS3_ACC_GYRO_Get_GetTimestamp(u8_t *buff)
+* Function Name  : mems_status_t LSM6DS3_ACC_GYRO_Get_GetTimestamp(u8_t *buff)
 * Description    : Read GetTimestamp output register
 * Input          : pointer to [u8_t]
 * Output         : GetTimestamp buffer u8_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_Get_GetTimestamp(void *handle, u8_t *buff)
+mems_status_t LSM6DS3_ACC_GYRO_Get_GetTimestamp(void *handle, u8_t *buff)
 {
   u8_t i, j, k;
   u8_t numberOfByteForDimension;
@@ -6339,13 +6339,13 @@ status_t LSM6DS3_ACC_GYRO_Get_GetTimestamp(void *handle, u8_t *buff)
 }
 
 /*******************************************************************************
-* Function Name  : status_t LSM6DS3_ACC_GYRO_Get_GetStepCounter(u8_t *buff)
+* Function Name  : mems_status_t LSM6DS3_ACC_GYRO_Get_GetStepCounter(u8_t *buff)
 * Description    : Read GetStepCounter output register
 * Input          : pointer to [u8_t]
 * Output         : GetStepCounter buffer u8_t
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_Get_GetStepCounter(void *handle, u8_t *buff)
+mems_status_t LSM6DS3_ACC_GYRO_Get_GetStepCounter(void *handle, u8_t *buff)
 {
   u8_t i, j, k;
   u8_t numberOfByteForDimension;
@@ -6373,7 +6373,7 @@ status_t LSM6DS3_ACC_GYRO_Get_GetStepCounter(void *handle, u8_t *buff)
 * Output         : None
 * Return         : Status [MEMS_ERROR, MEMS_SUCCESS]
 *******************************************************************************/
-status_t  LSM6DS3_ACC_GYRO_W_PedoThreshold(void *handle, u8_t newValue)
+mems_status_t  LSM6DS3_ACC_GYRO_W_PedoThreshold(void *handle, u8_t newValue)
 {
   u8_t value;
 
@@ -6403,7 +6403,7 @@ status_t  LSM6DS3_ACC_GYRO_W_PedoThreshold(void *handle, u8_t newValue)
  * The SI_Matrix buffer must provide coefficients
  * in xx, xy, xz, yx, yy, yz, zx, zy, zz order.
  */
-status_t LSM6DS3_ACC_GYRO_SH_init_SI_Matrix(void *handle, u8_t *SI_matrix)
+mems_status_t LSM6DS3_ACC_GYRO_SH_init_SI_Matrix(void *handle, u8_t *SI_matrix)
 {
   /* Open Embedded Function Register page*/
   LSM6DS3_ACC_GYRO_W_EmbeddedAccess(handle, LSM6DS3H_ACC_GYRO_FUNC_CFG_ENABLED);
@@ -6418,7 +6418,7 @@ status_t LSM6DS3_ACC_GYRO_SH_init_SI_Matrix(void *handle, u8_t *SI_matrix)
 }
 
 /* Read a remote device through I2C Sensor Hub Slave 0 */
-status_t LSM6DS3_ACC_GYRO_SH0_Program(void *handle, u8_t SlvAddr, u8_t Reg, u8_t len)
+mems_status_t LSM6DS3_ACC_GYRO_SH0_Program(void *handle, u8_t SlvAddr, u8_t Reg, u8_t len)
 {
   /* Open Embedded Function Register page*/
   LSM6DS3_ACC_GYRO_W_EmbeddedAccess(handle, LSM6DS3H_ACC_GYRO_FUNC_CFG_ENABLED);
@@ -6447,7 +6447,7 @@ status_t LSM6DS3_ACC_GYRO_SH0_Program(void *handle, u8_t SlvAddr, u8_t Reg, u8_t
 }
 
 /* Read a remote device through I2C Sensor Hub Slave 0 */
-status_t LSM6DS3_ACC_GYRO_SH0_ReadMem(void *handle, u8_t SlvAddr, u8_t Reg, u8_t *Bufp, u8_t len, u8_t stop)
+mems_status_t LSM6DS3_ACC_GYRO_SH0_ReadMem(void *handle, u8_t SlvAddr, u8_t Reg, u8_t *Bufp, u8_t len, u8_t stop)
 {
   LSM6DS3_ACC_GYRO_SENS_HUB_END_t op_cmpl = LSM6DS3_ACC_GYRO_SENS_HUB_END_STILL_ONGOING;
 
@@ -6474,7 +6474,7 @@ status_t LSM6DS3_ACC_GYRO_SH0_ReadMem(void *handle, u8_t SlvAddr, u8_t Reg, u8_t
 }
 
 /* Write a remote device through I2C Sensor Hub Slave 0 */
-status_t LSM6DS3_ACC_GYRO_SH0_WriteByte(void *handle, u8_t SlvAddr, u8_t Reg, u8_t Bufp)
+mems_status_t LSM6DS3_ACC_GYRO_SH0_WriteByte(void *handle, u8_t SlvAddr, u8_t Reg, u8_t Bufp)
 {
   /* Open Embedded Function Register page*/
   LSM6DS3_ACC_GYRO_W_EmbeddedAccess(handle, LSM6DS3H_ACC_GYRO_FUNC_CFG_ENABLED);

--- a/src/LSM6DS3_ACC_GYRO_driver.h
+++ b/src/LSM6DS3_ACC_GYRO_driver.h
@@ -89,7 +89,7 @@ typedef enum
 {
   MEMS_SUCCESS      =   0x01,
   MEMS_ERROR        =   0x00
-} status_t;
+} mems_status_t;
 
 #endif /*__SHARED__TYPES*/
 
@@ -237,7 +237,7 @@ typedef enum
 * Bit Group Name: None
 * Permission    : W
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_WriteReg( void *handle, u8_t Reg, u8_t *Bufp, u16_t len );
+mems_status_t LSM6DS3_ACC_GYRO_WriteReg( void *handle, u8_t Reg, u8_t *Bufp, u16_t len );
 
 /*******************************************************************************
 * Register      : Generic - All
@@ -245,7 +245,7 @@ status_t LSM6DS3_ACC_GYRO_WriteReg( void *handle, u8_t Reg, u8_t *Bufp, u16_t le
 * Bit Group Name: None
 * Permission    : R
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_ReadReg( void *handle, u8_t Reg, u8_t *Bufp, u16_t len );
+mems_status_t LSM6DS3_ACC_GYRO_ReadReg( void *handle, u8_t Reg, u8_t *Bufp, u16_t len );
 
 /**************** Base Function  *******************/
 
@@ -257,7 +257,7 @@ status_t LSM6DS3_ACC_GYRO_ReadReg( void *handle, u8_t Reg, u8_t *Bufp, u16_t len
 *******************************************************************************/
 #define   LSM6DS3_ACC_GYRO_WHO_AM_I_BIT_MASK    0xFF
 #define   LSM6DS3_ACC_GYRO_WHO_AM_I_BIT_POSITION    0
-status_t LSM6DS3_ACC_GYRO_R_WHO_AM_I(void *handle, u8_t *value);
+mems_status_t LSM6DS3_ACC_GYRO_R_WHO_AM_I(void *handle, u8_t *value);
 
 /*******************************************************************************
 * Register      : CTRL3_C
@@ -272,8 +272,8 @@ typedef enum
 } LSM6DS3_ACC_GYRO_BDU_t;
 
 #define   LSM6DS3_ACC_GYRO_BDU_MASK   0x40
-status_t  LSM6DS3_ACC_GYRO_W_BDU(void *handle, LSM6DS3_ACC_GYRO_BDU_t newValue);
-status_t LSM6DS3_ACC_GYRO_R_BDU(void *handle, LSM6DS3_ACC_GYRO_BDU_t *value);
+mems_status_t  LSM6DS3_ACC_GYRO_W_BDU(void *handle, LSM6DS3_ACC_GYRO_BDU_t newValue);
+mems_status_t LSM6DS3_ACC_GYRO_R_BDU(void *handle, LSM6DS3_ACC_GYRO_BDU_t *value);
 
 /*******************************************************************************
 * Register      : CTRL1_XL
@@ -290,16 +290,16 @@ typedef enum
 } LSM6DS3_ACC_GYRO_FS_XL_t;
 
 #define   LSM6DS3_ACC_GYRO_FS_XL_MASK   0x0C
-status_t  LSM6DS3_ACC_GYRO_W_FS_XL(void *handle, LSM6DS3_ACC_GYRO_FS_XL_t newValue);
-status_t LSM6DS3_ACC_GYRO_R_FS_XL(void *handle, LSM6DS3_ACC_GYRO_FS_XL_t *value);
+mems_status_t  LSM6DS3_ACC_GYRO_W_FS_XL(void *handle, LSM6DS3_ACC_GYRO_FS_XL_t newValue);
+mems_status_t LSM6DS3_ACC_GYRO_R_FS_XL(void *handle, LSM6DS3_ACC_GYRO_FS_XL_t *value);
 
 /*******************************************************************************
 * Register      : <REGISTER_L> - <REGISTER_H>
 * Output Type   : GetAccData
 * Permission    : RO
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_GetRawAccData(void *handle, u8_t *buff);
-status_t LSM6DS3_ACC_Get_Acceleration(void *handle, int *buff, u8_t from_fifo);
+mems_status_t LSM6DS3_ACC_GYRO_GetRawAccData(void *handle, u8_t *buff);
+mems_status_t LSM6DS3_ACC_Get_Acceleration(void *handle, int *buff, u8_t from_fifo);
 
 /*******************************************************************************
 * Register      : CTRL1_XL
@@ -323,9 +323,9 @@ typedef enum
 } LSM6DS3_ACC_GYRO_ODR_XL_t;
 
 #define   LSM6DS3_ACC_GYRO_ODR_XL_MASK    0xF0
-status_t  LSM6DS3_ACC_GYRO_W_ODR_XL(void *handle, LSM6DS3_ACC_GYRO_ODR_XL_t newValue);
-status_t LSM6DS3_ACC_GYRO_R_ODR_XL(void *handle, LSM6DS3_ACC_GYRO_ODR_XL_t *value);
-status_t LSM6DS3_ACC_GYRO_translate_ODR_XL(LSM6DS3_ACC_GYRO_ODR_XL_t value, u16_t *odr_hz_val);
+mems_status_t  LSM6DS3_ACC_GYRO_W_ODR_XL(void *handle, LSM6DS3_ACC_GYRO_ODR_XL_t newValue);
+mems_status_t LSM6DS3_ACC_GYRO_R_ODR_XL(void *handle, LSM6DS3_ACC_GYRO_ODR_XL_t *value);
+mems_status_t LSM6DS3_ACC_GYRO_translate_ODR_XL(LSM6DS3_ACC_GYRO_ODR_XL_t value, u16_t *odr_hz_val);
 
 /*******************************************************************************
 * Register      : CTRL2_G
@@ -342,8 +342,8 @@ typedef enum
 } LSM6DS3_ACC_GYRO_FS_G_t;
 
 #define   LSM6DS3_ACC_GYRO_FS_G_MASK    0x0C
-status_t  LSM6DS3_ACC_GYRO_W_FS_G(void *handle, LSM6DS3_ACC_GYRO_FS_G_t newValue);
-status_t LSM6DS3_ACC_GYRO_R_FS_G(void *handle, LSM6DS3_ACC_GYRO_FS_G_t *value);
+mems_status_t  LSM6DS3_ACC_GYRO_W_FS_G(void *handle, LSM6DS3_ACC_GYRO_FS_G_t newValue);
+mems_status_t LSM6DS3_ACC_GYRO_R_FS_G(void *handle, LSM6DS3_ACC_GYRO_FS_G_t *value);
 
 /*******************************************************************************
 * Register      : CTRL2_G
@@ -365,17 +365,17 @@ typedef enum
 } LSM6DS3_ACC_GYRO_ODR_G_t;
 
 #define   LSM6DS3_ACC_GYRO_ODR_G_MASK   0xF0
-status_t  LSM6DS3_ACC_GYRO_W_ODR_G(void *handle, LSM6DS3_ACC_GYRO_ODR_G_t newValue);
-status_t LSM6DS3_ACC_GYRO_R_ODR_G(void *handle, LSM6DS3_ACC_GYRO_ODR_G_t *value);
-status_t LSM6DS3_ACC_GYRO_translate_ODR_G(LSM6DS3_ACC_GYRO_ODR_G_t value, u16_t *odr_hz_val);
+mems_status_t  LSM6DS3_ACC_GYRO_W_ODR_G(void *handle, LSM6DS3_ACC_GYRO_ODR_G_t newValue);
+mems_status_t LSM6DS3_ACC_GYRO_R_ODR_G(void *handle, LSM6DS3_ACC_GYRO_ODR_G_t *value);
+mems_status_t LSM6DS3_ACC_GYRO_translate_ODR_G(LSM6DS3_ACC_GYRO_ODR_G_t value, u16_t *odr_hz_val);
 
 /*******************************************************************************
 * Register      : <REGISTER_L> - <REGISTER_H>
 * Output Type   : GetGyroData
 * Permission    : RO
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_GetRawGyroData(void *handle, u8_t *buff);
-status_t LSM6DS3_ACC_Get_AngularRate(void *handle, int *buff, u8_t from_fifo);
+mems_status_t LSM6DS3_ACC_GYRO_GetRawGyroData(void *handle, u8_t *buff);
+mems_status_t LSM6DS3_ACC_Get_AngularRate(void *handle, int *buff, u8_t from_fifo);
 
 /*******************************************************************************
 * Register      : CTRL1_XL
@@ -392,8 +392,8 @@ typedef enum
 } LSM6DS3_ACC_GYRO_BW_XL_t;
 
 #define   LSM6DS3_ACC_GYRO_BW_XL_MASK   0x03
-status_t  LSM6DS3_ACC_GYRO_W_BW_XL(void *handle, LSM6DS3_ACC_GYRO_BW_XL_t newValue);
-status_t LSM6DS3_ACC_GYRO_R_BW_XL(void *handle, LSM6DS3_ACC_GYRO_BW_XL_t *value);
+mems_status_t  LSM6DS3_ACC_GYRO_W_BW_XL(void *handle, LSM6DS3_ACC_GYRO_BW_XL_t newValue);
+mems_status_t LSM6DS3_ACC_GYRO_R_BW_XL(void *handle, LSM6DS3_ACC_GYRO_BW_XL_t *value);
 
 /*******************************************************************************
 * Register      : CTRL2_G
@@ -408,8 +408,8 @@ typedef enum
 } LSM6DS3_ACC_GYRO_FS_125_t;
 
 #define   LSM6DS3_ACC_GYRO_FS_125_MASK    0x02
-status_t  LSM6DS3_ACC_GYRO_W_FS_125(void *handle, LSM6DS3_ACC_GYRO_FS_125_t newValue);
-status_t LSM6DS3_ACC_GYRO_R_FS_125(void *handle, LSM6DS3_ACC_GYRO_FS_125_t *value);
+mems_status_t  LSM6DS3_ACC_GYRO_W_FS_125(void *handle, LSM6DS3_ACC_GYRO_FS_125_t newValue);
+mems_status_t LSM6DS3_ACC_GYRO_R_FS_125(void *handle, LSM6DS3_ACC_GYRO_FS_125_t *value);
 
 /**************** Advanced Function  *******************/
 
@@ -426,8 +426,8 @@ typedef enum
 } LSM6DS3_ACC_GYRO_EMB_ACC_t;
 
 #define   LSM6DSM_ACC_GYRO_EMB_ACC_MASK   0x80
-status_t  LSM6DS3_ACC_GYRO_W_EmbeddedAccess(void *handle, LSM6DS3_ACC_GYRO_EMB_ACC_t newValue);
-status_t LSM6DS3_ACC_GYRO_R_EmbeddedAccess(void *handle, LSM6DS3_ACC_GYRO_EMB_ACC_t *value);
+mems_status_t  LSM6DS3_ACC_GYRO_W_EmbeddedAccess(void *handle, LSM6DS3_ACC_GYRO_EMB_ACC_t newValue);
+mems_status_t LSM6DS3_ACC_GYRO_R_EmbeddedAccess(void *handle, LSM6DS3_ACC_GYRO_EMB_ACC_t *value);
 
 /*******************************************************************************
 * Register      : SENSOR_SYNC_TIME
@@ -437,8 +437,8 @@ status_t LSM6DS3_ACC_GYRO_R_EmbeddedAccess(void *handle, LSM6DS3_ACC_GYRO_EMB_AC
 *******************************************************************************/
 #define   LSM6DS3_ACC_GYRO_TPH_MASK   0xFF
 #define   LSM6DS3_ACC_GYRO_TPH_POSITION   0
-status_t  LSM6DS3_ACC_GYRO_W_Stamping_Time_Frame(void *handle, u8_t newValue);
-status_t LSM6DS3_ACC_GYRO_R_Stamping_Time_Frame(void *handle, u8_t *value);
+mems_status_t  LSM6DS3_ACC_GYRO_W_Stamping_Time_Frame(void *handle, u8_t newValue);
+mems_status_t LSM6DS3_ACC_GYRO_R_Stamping_Time_Frame(void *handle, u8_t *value);
 
 /*******************************************************************************
 * Register      : FIFO_CTRL1
@@ -450,8 +450,8 @@ status_t LSM6DS3_ACC_GYRO_R_Stamping_Time_Frame(void *handle, u8_t *value);
 #define   LSM6DS3_ACC_GYRO_WTM_FIFO_CTRL1_POSITION    0
 #define   LSM6DS3_ACC_GYRO_WTM_FIFO_CTRL2_MASK    0x0F
 #define   LSM6DS3_ACC_GYRO_WTM_FIFO_CTRL2_POSITION    0
-status_t  LSM6DS3_ACC_GYRO_W_FIFO_Watermark(void *handle, u16_t newValue);
-status_t LSM6DS3_ACC_GYRO_R_FIFO_Watermark(void *handle, u16_t *value);
+mems_status_t  LSM6DS3_ACC_GYRO_W_FIFO_Watermark(void *handle, u16_t newValue);
+mems_status_t LSM6DS3_ACC_GYRO_R_FIFO_Watermark(void *handle, u16_t *value);
 
 /*******************************************************************************
 * Register      : FIFO_CTRL2
@@ -466,8 +466,8 @@ typedef enum
 } LSM6DS3_ACC_GYRO_TIM_PEDO_FIFO_DRDY_t;
 
 #define   LSM6DS3_ACC_GYRO_TIM_PEDO_FIFO_DRDY_MASK    0x40
-status_t  LSM6DS3_ACC_GYRO_W_TIM_PEDO_FIFO_Write_En(void *handle, LSM6DS3_ACC_GYRO_TIM_PEDO_FIFO_DRDY_t newValue);
-status_t LSM6DS3_ACC_GYRO_R_TIM_PEDO_FIFO_Write_En(void *handle, LSM6DS3_ACC_GYRO_TIM_PEDO_FIFO_DRDY_t *value);
+mems_status_t  LSM6DS3_ACC_GYRO_W_TIM_PEDO_FIFO_Write_En(void *handle, LSM6DS3_ACC_GYRO_TIM_PEDO_FIFO_DRDY_t newValue);
+mems_status_t LSM6DS3_ACC_GYRO_R_TIM_PEDO_FIFO_Write_En(void *handle, LSM6DS3_ACC_GYRO_TIM_PEDO_FIFO_DRDY_t *value);
 
 /*******************************************************************************
 * Register      : FIFO_CTRL2
@@ -482,8 +482,8 @@ typedef enum
 } LSM6DS3_ACC_GYRO_TIM_PEDO_FIFO_EN_t;
 
 #define   LSM6DS3_ACC_GYRO_TIM_PEDO_FIFO_EN_MASK    0x80
-status_t  LSM6DS3_ACC_GYRO_W_TIM_PEDO_FIFO_En(void *handle, LSM6DS3_ACC_GYRO_TIM_PEDO_FIFO_EN_t newValue);
-status_t LSM6DS3_ACC_GYRO_R_TIM_PEDO_FIFO_En(void *handle, LSM6DS3_ACC_GYRO_TIM_PEDO_FIFO_EN_t *value);
+mems_status_t  LSM6DS3_ACC_GYRO_W_TIM_PEDO_FIFO_En(void *handle, LSM6DS3_ACC_GYRO_TIM_PEDO_FIFO_EN_t newValue);
+mems_status_t LSM6DS3_ACC_GYRO_R_TIM_PEDO_FIFO_En(void *handle, LSM6DS3_ACC_GYRO_TIM_PEDO_FIFO_EN_t *value);
 
 /*******************************************************************************
 * Register      : FIFO_CTRL3
@@ -504,9 +504,9 @@ typedef enum
 } LSM6DS3_ACC_GYRO_DEC_FIFO_XL_t;
 
 #define   LSM6DS3_ACC_GYRO_DEC_FIFO_XL_MASK   0x07
-status_t  LSM6DS3_ACC_GYRO_W_DEC_FIFO_XL(void *handle, LSM6DS3_ACC_GYRO_DEC_FIFO_XL_t newValue);
-status_t  LSM6DS3_ACC_GYRO_W_DEC_FIFO_XL_val(void *handle, u16_t newValue);
-status_t LSM6DS3_ACC_GYRO_R_DEC_FIFO_XL(void *handle, LSM6DS3_ACC_GYRO_DEC_FIFO_XL_t *value);
+mems_status_t  LSM6DS3_ACC_GYRO_W_DEC_FIFO_XL(void *handle, LSM6DS3_ACC_GYRO_DEC_FIFO_XL_t newValue);
+mems_status_t  LSM6DS3_ACC_GYRO_W_DEC_FIFO_XL_val(void *handle, u16_t newValue);
+mems_status_t LSM6DS3_ACC_GYRO_R_DEC_FIFO_XL(void *handle, LSM6DS3_ACC_GYRO_DEC_FIFO_XL_t *value);
 
 /*******************************************************************************
 * Register      : FIFO_CTRL3
@@ -527,9 +527,9 @@ typedef enum
 } LSM6DS3_ACC_GYRO_DEC_FIFO_G_t;
 
 #define   LSM6DS3_ACC_GYRO_DEC_FIFO_G_MASK    0x38
-status_t  LSM6DS3_ACC_GYRO_W_DEC_FIFO_G(void *handle, LSM6DS3_ACC_GYRO_DEC_FIFO_G_t newValue);
-status_t  LSM6DS3_ACC_GYRO_W_DEC_FIFO_G_val(void *handle, u16_t newValue);
-status_t LSM6DS3_ACC_GYRO_R_DEC_FIFO_G(void *handle, LSM6DS3_ACC_GYRO_DEC_FIFO_G_t *value);
+mems_status_t  LSM6DS3_ACC_GYRO_W_DEC_FIFO_G(void *handle, LSM6DS3_ACC_GYRO_DEC_FIFO_G_t newValue);
+mems_status_t  LSM6DS3_ACC_GYRO_W_DEC_FIFO_G_val(void *handle, u16_t newValue);
+mems_status_t LSM6DS3_ACC_GYRO_R_DEC_FIFO_G(void *handle, LSM6DS3_ACC_GYRO_DEC_FIFO_G_t *value);
 
 /*******************************************************************************
 * Register      : FIFO_CTRL4
@@ -550,8 +550,8 @@ typedef enum
 } LSM6DS3_ACC_GYRO_DEC_FIFO_SLV0_t;
 
 #define   LSM6DS3_ACC_GYRO_DEC_FIFO_SLV0_MASK   0x07
-status_t  LSM6DS3_ACC_GYRO_W_DEC_FIFO_SLV0(void *handle, LSM6DS3_ACC_GYRO_DEC_FIFO_SLV0_t newValue);
-status_t LSM6DS3_ACC_GYRO_R_DEC_FIFO_SLV0(void *handle, LSM6DS3_ACC_GYRO_DEC_FIFO_SLV0_t *value);
+mems_status_t  LSM6DS3_ACC_GYRO_W_DEC_FIFO_SLV0(void *handle, LSM6DS3_ACC_GYRO_DEC_FIFO_SLV0_t newValue);
+mems_status_t LSM6DS3_ACC_GYRO_R_DEC_FIFO_SLV0(void *handle, LSM6DS3_ACC_GYRO_DEC_FIFO_SLV0_t *value);
 
 /*******************************************************************************
 * Register      : FIFO_CTRL4
@@ -572,8 +572,8 @@ typedef enum
 } LSM6DS3_ACC_GYRO_DEC_FIFO_SLV1_t;
 
 #define   LSM6DS3_ACC_GYRO_DEC_FIFO_SLV1_MASK   0x38
-status_t  LSM6DS3_ACC_GYRO_W_DEC_FIFO_SLV1(void *handle, LSM6DS3_ACC_GYRO_DEC_FIFO_SLV1_t newValue);
-status_t LSM6DS3_ACC_GYRO_R_DEC_FIFO_SLV1(void *handle, LSM6DS3_ACC_GYRO_DEC_FIFO_SLV1_t *value);
+mems_status_t  LSM6DS3_ACC_GYRO_W_DEC_FIFO_SLV1(void *handle, LSM6DS3_ACC_GYRO_DEC_FIFO_SLV1_t newValue);
+mems_status_t LSM6DS3_ACC_GYRO_R_DEC_FIFO_SLV1(void *handle, LSM6DS3_ACC_GYRO_DEC_FIFO_SLV1_t *value);
 
 /*******************************************************************************
 * Register      : FIFO_CTRL4
@@ -588,8 +588,8 @@ typedef enum
 } LSM6DS3_ACC_GYRO_HI_DATA_ONLY_t;
 
 #define   LSM6DS3_ACC_GYRO_HI_DATA_ONLY_MASK    0x40
-status_t  LSM6DS3_ACC_GYRO_W_HI_DATA_ONLY(void *handle, LSM6DS3_ACC_GYRO_HI_DATA_ONLY_t newValue);
-status_t LSM6DS3_ACC_GYRO_R_HI_DATA_ONLY(void *handle, LSM6DS3_ACC_GYRO_HI_DATA_ONLY_t *value);
+mems_status_t  LSM6DS3_ACC_GYRO_W_HI_DATA_ONLY(void *handle, LSM6DS3_ACC_GYRO_HI_DATA_ONLY_t newValue);
+mems_status_t LSM6DS3_ACC_GYRO_R_HI_DATA_ONLY(void *handle, LSM6DS3_ACC_GYRO_HI_DATA_ONLY_t *value);
 
 /*******************************************************************************
 * Register      : FIFO_CTRL5
@@ -610,8 +610,8 @@ typedef enum
 } LSM6DS3_ACC_GYRO_FIFO_MODE_t;
 
 #define   LSM6DS3_ACC_GYRO_FIFO_MODE_MASK   0x07
-status_t  LSM6DS3_ACC_GYRO_W_FIFO_MODE(void *handle, LSM6DS3_ACC_GYRO_FIFO_MODE_t newValue);
-status_t LSM6DS3_ACC_GYRO_R_FIFO_MODE(void *handle, LSM6DS3_ACC_GYRO_FIFO_MODE_t *value);
+mems_status_t  LSM6DS3_ACC_GYRO_W_FIFO_MODE(void *handle, LSM6DS3_ACC_GYRO_FIFO_MODE_t newValue);
+mems_status_t LSM6DS3_ACC_GYRO_R_FIFO_MODE(void *handle, LSM6DS3_ACC_GYRO_FIFO_MODE_t *value);
 
 /*******************************************************************************
 * Register      : FIFO_CTRL5
@@ -634,8 +634,8 @@ typedef enum
 } LSM6DS3_ACC_GYRO_ODR_FIFO_t;
 
 #define   LSM6DS3_ACC_GYRO_ODR_FIFO_MASK    0x78
-status_t  LSM6DS3_ACC_GYRO_W_ODR_FIFO(void *handle, LSM6DS3_ACC_GYRO_ODR_FIFO_t newValue);
-status_t LSM6DS3_ACC_GYRO_R_ODR_FIFO(void *handle, LSM6DS3_ACC_GYRO_ODR_FIFO_t *value);
+mems_status_t  LSM6DS3_ACC_GYRO_W_ODR_FIFO(void *handle, LSM6DS3_ACC_GYRO_ODR_FIFO_t newValue);
+mems_status_t LSM6DS3_ACC_GYRO_R_ODR_FIFO(void *handle, LSM6DS3_ACC_GYRO_ODR_FIFO_t *value);
 
 /*******************************************************************************
 * Register      : ORIENT_CFG_G
@@ -654,8 +654,8 @@ typedef enum
 } LSM6DS3_ACC_GYRO_ORIENT_t;
 
 #define   LSM6DS3_ACC_GYRO_ORIENT_MASK    0x07
-status_t  LSM6DS3_ACC_GYRO_W_Orientation(void *handle, LSM6DS3_ACC_GYRO_ORIENT_t newValue);
-status_t LSM6DS3_ACC_GYRO_R_Orientation(void *handle, LSM6DS3_ACC_GYRO_ORIENT_t *value);
+mems_status_t  LSM6DS3_ACC_GYRO_W_Orientation(void *handle, LSM6DS3_ACC_GYRO_ORIENT_t newValue);
+mems_status_t LSM6DS3_ACC_GYRO_R_Orientation(void *handle, LSM6DS3_ACC_GYRO_ORIENT_t *value);
 
 /*******************************************************************************
 * Register      : ORIENT_CFG_G
@@ -670,8 +670,8 @@ typedef enum
 } LSM6DS3_ACC_GYRO_SIGN_Z_G_t;
 
 #define   LSM6DS3_ACC_GYRO_SIGN_Z_G_MASK    0x08
-status_t  LSM6DS3_ACC_GYRO_W_SignZ_G(void *handle, LSM6DS3_ACC_GYRO_SIGN_Z_G_t newValue);
-status_t LSM6DS3_ACC_GYRO_R_SignZ_G(void *handle, LSM6DS3_ACC_GYRO_SIGN_Z_G_t *value);
+mems_status_t  LSM6DS3_ACC_GYRO_W_SignZ_G(void *handle, LSM6DS3_ACC_GYRO_SIGN_Z_G_t newValue);
+mems_status_t LSM6DS3_ACC_GYRO_R_SignZ_G(void *handle, LSM6DS3_ACC_GYRO_SIGN_Z_G_t *value);
 
 /*******************************************************************************
 * Register      : ORIENT_CFG_G
@@ -686,8 +686,8 @@ typedef enum
 } LSM6DS3_ACC_GYRO_SIGN_Y_G_t;
 
 #define   LSM6DS3_ACC_GYRO_SIGN_Y_G_MASK    0x10
-status_t  LSM6DS3_ACC_GYRO_W_SignY_G(void *handle, LSM6DS3_ACC_GYRO_SIGN_Y_G_t newValue);
-status_t LSM6DS3_ACC_GYRO_R_SignY_G(void *handle, LSM6DS3_ACC_GYRO_SIGN_Y_G_t *value);
+mems_status_t  LSM6DS3_ACC_GYRO_W_SignY_G(void *handle, LSM6DS3_ACC_GYRO_SIGN_Y_G_t newValue);
+mems_status_t LSM6DS3_ACC_GYRO_R_SignY_G(void *handle, LSM6DS3_ACC_GYRO_SIGN_Y_G_t *value);
 
 /*******************************************************************************
 * Register      : ORIENT_CFG_G
@@ -702,8 +702,8 @@ typedef enum
 } LSM6DS3_ACC_GYRO_SIGN_X_G_t;
 
 #define   LSM6DS3_ACC_GYRO_SIGN_X_G_MASK    0x20
-status_t  LSM6DS3_ACC_GYRO_W_SignX_G(void *handle, LSM6DS3_ACC_GYRO_SIGN_X_G_t newValue);
-status_t LSM6DS3_ACC_GYRO_R_SignX_G(void *handle, LSM6DS3_ACC_GYRO_SIGN_X_G_t *value);
+mems_status_t  LSM6DS3_ACC_GYRO_W_SignX_G(void *handle, LSM6DS3_ACC_GYRO_SIGN_X_G_t newValue);
+mems_status_t LSM6DS3_ACC_GYRO_R_SignX_G(void *handle, LSM6DS3_ACC_GYRO_SIGN_X_G_t *value);
 
 /*******************************************************************************
 * Register      : INT1_CTRL
@@ -718,8 +718,8 @@ typedef enum
 } LSM6DS3_ACC_GYRO_INT1_DRDY_XL_t;
 
 #define   LSM6DS3_ACC_GYRO_INT1_DRDY_XL_MASK    0x01
-status_t  LSM6DS3_ACC_GYRO_W_DRDY_XL_on_INT1(void *handle, LSM6DS3_ACC_GYRO_INT1_DRDY_XL_t newValue);
-status_t LSM6DS3_ACC_GYRO_R_DRDY_XL_on_INT1(void *handle, LSM6DS3_ACC_GYRO_INT1_DRDY_XL_t *value);
+mems_status_t  LSM6DS3_ACC_GYRO_W_DRDY_XL_on_INT1(void *handle, LSM6DS3_ACC_GYRO_INT1_DRDY_XL_t newValue);
+mems_status_t LSM6DS3_ACC_GYRO_R_DRDY_XL_on_INT1(void *handle, LSM6DS3_ACC_GYRO_INT1_DRDY_XL_t *value);
 
 /*******************************************************************************
 * Register      : INT1_CTRL
@@ -734,8 +734,8 @@ typedef enum
 } LSM6DS3_ACC_GYRO_INT1_DRDY_G_t;
 
 #define   LSM6DS3_ACC_GYRO_INT1_DRDY_G_MASK   0x02
-status_t  LSM6DS3_ACC_GYRO_W_DRDY_G_on_INT1(void *handle, LSM6DS3_ACC_GYRO_INT1_DRDY_G_t newValue);
-status_t LSM6DS3_ACC_GYRO_R_DRDY_G_on_INT1(void *handle, LSM6DS3_ACC_GYRO_INT1_DRDY_G_t *value);
+mems_status_t  LSM6DS3_ACC_GYRO_W_DRDY_G_on_INT1(void *handle, LSM6DS3_ACC_GYRO_INT1_DRDY_G_t newValue);
+mems_status_t LSM6DS3_ACC_GYRO_R_DRDY_G_on_INT1(void *handle, LSM6DS3_ACC_GYRO_INT1_DRDY_G_t *value);
 
 /*******************************************************************************
 * Register      : INT1_CTRL
@@ -750,8 +750,8 @@ typedef enum
 } LSM6DS3_ACC_GYRO_INT1_BOOT_t;
 
 #define   LSM6DS3_ACC_GYRO_INT1_BOOT_MASK   0x04
-status_t  LSM6DS3_ACC_GYRO_W_BOOT_on_INT1(void *handle, LSM6DS3_ACC_GYRO_INT1_BOOT_t newValue);
-status_t LSM6DS3_ACC_GYRO_R_BOOT_on_INT1(void *handle, LSM6DS3_ACC_GYRO_INT1_BOOT_t *value);
+mems_status_t  LSM6DS3_ACC_GYRO_W_BOOT_on_INT1(void *handle, LSM6DS3_ACC_GYRO_INT1_BOOT_t newValue);
+mems_status_t LSM6DS3_ACC_GYRO_R_BOOT_on_INT1(void *handle, LSM6DS3_ACC_GYRO_INT1_BOOT_t *value);
 
 /*******************************************************************************
 * Register      : INT1_CTRL
@@ -766,8 +766,8 @@ typedef enum
 } LSM6DS3_ACC_GYRO_INT1_FTH_t;
 
 #define   LSM6DS3_ACC_GYRO_INT1_FTH_MASK    0x08
-status_t  LSM6DS3_ACC_GYRO_W_FIFO_TSHLD_on_INT1(void *handle, LSM6DS3_ACC_GYRO_INT1_FTH_t newValue);
-status_t LSM6DS3_ACC_GYRO_R_FIFO_TSHLD_on_INT1(void *handle, LSM6DS3_ACC_GYRO_INT1_FTH_t *value);
+mems_status_t  LSM6DS3_ACC_GYRO_W_FIFO_TSHLD_on_INT1(void *handle, LSM6DS3_ACC_GYRO_INT1_FTH_t newValue);
+mems_status_t LSM6DS3_ACC_GYRO_R_FIFO_TSHLD_on_INT1(void *handle, LSM6DS3_ACC_GYRO_INT1_FTH_t *value);
 
 /*******************************************************************************
 * Register      : INT1_CTRL
@@ -782,8 +782,8 @@ typedef enum
 } LSM6DS3_ACC_GYRO_INT1_OVR_t;
 
 #define   LSM6DS3_ACC_GYRO_INT1_OVR_MASK    0x10
-status_t  LSM6DS3_ACC_GYRO_W_OVERRUN_on_INT1(void *handle, LSM6DS3_ACC_GYRO_INT1_OVR_t newValue);
-status_t LSM6DS3_ACC_GYRO_R_OVERRUN_on_INT1(void *handle, LSM6DS3_ACC_GYRO_INT1_OVR_t *value);
+mems_status_t  LSM6DS3_ACC_GYRO_W_OVERRUN_on_INT1(void *handle, LSM6DS3_ACC_GYRO_INT1_OVR_t newValue);
+mems_status_t LSM6DS3_ACC_GYRO_R_OVERRUN_on_INT1(void *handle, LSM6DS3_ACC_GYRO_INT1_OVR_t *value);
 
 /*******************************************************************************
 * Register      : INT1_CTRL
@@ -798,8 +798,8 @@ typedef enum
 } LSM6DS3_ACC_GYRO_INT1_FSS5_t;
 
 #define   LSM6DS3_ACC_GYRO_INT1_FSS5_MASK   0x20
-status_t  LSM6DS3_ACC_GYRO_W_FSS5_on_INT1(void *handle, LSM6DS3_ACC_GYRO_INT1_FSS5_t newValue);
-status_t LSM6DS3_ACC_GYRO_R_FSS5_on_INT1(void *handle, LSM6DS3_ACC_GYRO_INT1_FSS5_t *value);
+mems_status_t  LSM6DS3_ACC_GYRO_W_FSS5_on_INT1(void *handle, LSM6DS3_ACC_GYRO_INT1_FSS5_t newValue);
+mems_status_t LSM6DS3_ACC_GYRO_R_FSS5_on_INT1(void *handle, LSM6DS3_ACC_GYRO_INT1_FSS5_t *value);
 
 /*******************************************************************************
 * Register      : INT1_CTRL
@@ -814,8 +814,8 @@ typedef enum
 } LSM6DS3_ACC_GYRO_INT1_SIGN_MOT_t;
 
 #define   LSM6DS3_ACC_GYRO_INT1_SIGN_MOT_MASK   0x40
-status_t  LSM6DS3_ACC_GYRO_W_SIGN_MOT_on_INT1(void *handle, LSM6DS3_ACC_GYRO_INT1_SIGN_MOT_t newValue);
-status_t LSM6DS3_ACC_GYRO_R_SIGN_MOT_on_INT1(void *handle, LSM6DS3_ACC_GYRO_INT1_SIGN_MOT_t *value);
+mems_status_t  LSM6DS3_ACC_GYRO_W_SIGN_MOT_on_INT1(void *handle, LSM6DS3_ACC_GYRO_INT1_SIGN_MOT_t newValue);
+mems_status_t LSM6DS3_ACC_GYRO_R_SIGN_MOT_on_INT1(void *handle, LSM6DS3_ACC_GYRO_INT1_SIGN_MOT_t *value);
 
 /*******************************************************************************
 * Register      : INT1_CTRL
@@ -830,8 +830,8 @@ typedef enum
 } LSM6DS3_ACC_GYRO_INT1_PEDO_t;
 
 #define   LSM6DS3_ACC_GYRO_INT1_PEDO_MASK   0x80
-status_t  LSM6DS3_ACC_GYRO_W_PEDO_STEP_on_INT1(void *handle, LSM6DS3_ACC_GYRO_INT1_PEDO_t newValue);
-status_t LSM6DS3_ACC_GYRO_R_PEDO_STEP_on_INT1(void *handle, LSM6DS3_ACC_GYRO_INT1_PEDO_t *value);
+mems_status_t  LSM6DS3_ACC_GYRO_W_PEDO_STEP_on_INT1(void *handle, LSM6DS3_ACC_GYRO_INT1_PEDO_t newValue);
+mems_status_t LSM6DS3_ACC_GYRO_R_PEDO_STEP_on_INT1(void *handle, LSM6DS3_ACC_GYRO_INT1_PEDO_t *value);
 
 /*******************************************************************************
 * Register      : INT2_CTRL
@@ -846,8 +846,8 @@ typedef enum
 } LSM6DS3_ACC_GYRO_INT2_DRDY_XL_t;
 
 #define   LSM6DS3_ACC_GYRO_INT2_DRDY_XL_MASK    0x01
-status_t  LSM6DS3_ACC_GYRO_W_DRDY_XL_on_INT2(void *handle, LSM6DS3_ACC_GYRO_INT2_DRDY_XL_t newValue);
-status_t LSM6DS3_ACC_GYRO_R_DRDY_XL_on_INT2(void *handle, LSM6DS3_ACC_GYRO_INT2_DRDY_XL_t *value);
+mems_status_t  LSM6DS3_ACC_GYRO_W_DRDY_XL_on_INT2(void *handle, LSM6DS3_ACC_GYRO_INT2_DRDY_XL_t newValue);
+mems_status_t LSM6DS3_ACC_GYRO_R_DRDY_XL_on_INT2(void *handle, LSM6DS3_ACC_GYRO_INT2_DRDY_XL_t *value);
 
 /*******************************************************************************
 * Register      : INT2_CTRL
@@ -862,8 +862,8 @@ typedef enum
 } LSM6DS3_ACC_GYRO_INT2_DRDY_G_t;
 
 #define   LSM6DS3_ACC_GYRO_INT2_DRDY_G_MASK   0x02
-status_t  LSM6DS3_ACC_GYRO_W_DRDY_G_on_INT2(void *handle, LSM6DS3_ACC_GYRO_INT2_DRDY_G_t newValue);
-status_t LSM6DS3_ACC_GYRO_R_DRDY_G_on_INT2(void *handle, LSM6DS3_ACC_GYRO_INT2_DRDY_G_t *value);
+mems_status_t  LSM6DS3_ACC_GYRO_W_DRDY_G_on_INT2(void *handle, LSM6DS3_ACC_GYRO_INT2_DRDY_G_t newValue);
+mems_status_t LSM6DS3_ACC_GYRO_R_DRDY_G_on_INT2(void *handle, LSM6DS3_ACC_GYRO_INT2_DRDY_G_t *value);
 
 /*******************************************************************************
 * Register      : INT2_CTRL
@@ -878,8 +878,8 @@ typedef enum
 } LSM6DS3_ACC_GYRO_INT2_DRDY_TEMP_t;
 
 #define   LSM6DS3_ACC_GYRO_INT2_DRDY_TEMP_MASK    0x04
-status_t LSM6DS3_ACC_GYRO_W_DRDY_TEMP_on_INT2(void *handle, LSM6DS3_ACC_GYRO_INT2_DRDY_TEMP_t newValue);
-status_t LSM6DS3_ACC_GYRO_R_DRDY_TEMP_on_INT2(void *handle, LSM6DS3_ACC_GYRO_INT2_DRDY_TEMP_t *value);
+mems_status_t LSM6DS3_ACC_GYRO_W_DRDY_TEMP_on_INT2(void *handle, LSM6DS3_ACC_GYRO_INT2_DRDY_TEMP_t newValue);
+mems_status_t LSM6DS3_ACC_GYRO_R_DRDY_TEMP_on_INT2(void *handle, LSM6DS3_ACC_GYRO_INT2_DRDY_TEMP_t *value);
 
 
 /*******************************************************************************
@@ -895,8 +895,8 @@ typedef enum
 } LSM6DS3_ACC_GYRO_INT2_FTH_t;
 
 #define   LSM6DS3_ACC_GYRO_INT2_FTH_MASK    0x08
-status_t  LSM6DS3_ACC_GYRO_W_FIFO_TSHLD_on_INT2(void *handle, LSM6DS3_ACC_GYRO_INT2_FTH_t newValue);
-status_t LSM6DS3_ACC_GYRO_R_FIFO_TSHLD_on_INT2(void *handle, LSM6DS3_ACC_GYRO_INT2_FTH_t *value);
+mems_status_t  LSM6DS3_ACC_GYRO_W_FIFO_TSHLD_on_INT2(void *handle, LSM6DS3_ACC_GYRO_INT2_FTH_t newValue);
+mems_status_t LSM6DS3_ACC_GYRO_R_FIFO_TSHLD_on_INT2(void *handle, LSM6DS3_ACC_GYRO_INT2_FTH_t *value);
 
 /*******************************************************************************
 * Register      : INT2_CTRL
@@ -911,8 +911,8 @@ typedef enum
 } LSM6DS3_ACC_GYRO_INT2_OVR_t;
 
 #define   LSM6DS3_ACC_GYRO_INT2_OVR_MASK    0x10
-status_t  LSM6DS3_ACC_GYRO_W_OVERRUN_on_INT2(void *handle, LSM6DS3_ACC_GYRO_INT2_OVR_t newValue);
-status_t LSM6DS3_ACC_GYRO_R_OVERRUN_on_INT2(void *handle, LSM6DS3_ACC_GYRO_INT2_OVR_t *value);
+mems_status_t  LSM6DS3_ACC_GYRO_W_OVERRUN_on_INT2(void *handle, LSM6DS3_ACC_GYRO_INT2_OVR_t newValue);
+mems_status_t LSM6DS3_ACC_GYRO_R_OVERRUN_on_INT2(void *handle, LSM6DS3_ACC_GYRO_INT2_OVR_t *value);
 
 /*******************************************************************************
 * Register      : INT2_CTRL
@@ -927,8 +927,8 @@ typedef enum
 } LSM6DS3_ACC_GYRO_INT2_FSS5_t;
 
 #define   LSM6DS3_ACC_GYRO_INT2_FSS5_MASK   0x20
-status_t  LSM6DS3_ACC_GYRO_W_FSS5_on_INT2(void *handle, LSM6DS3_ACC_GYRO_INT2_FSS5_t newValue);
-status_t LSM6DS3_ACC_GYRO_R_FSS5_on_INT2(void *handle, LSM6DS3_ACC_GYRO_INT2_FSS5_t *value);
+mems_status_t  LSM6DS3_ACC_GYRO_W_FSS5_on_INT2(void *handle, LSM6DS3_ACC_GYRO_INT2_FSS5_t newValue);
+mems_status_t LSM6DS3_ACC_GYRO_R_FSS5_on_INT2(void *handle, LSM6DS3_ACC_GYRO_INT2_FSS5_t *value);
 
 /*******************************************************************************
 * Register      : INT2_CTRL
@@ -943,8 +943,8 @@ typedef enum
 } LSM6DS3_ACC_GYRO_INT2_SIGN_MOT_t;
 
 #define   LSM6DS3_ACC_GYRO_INT2_SIGN_MOT_MASK   0x40
-status_t  LSM6DS3_ACC_GYRO_W_SIGN_MOT_on_INT2(void *handle, LSM6DS3_ACC_GYRO_INT2_SIGN_MOT_t newValue);
-status_t LSM6DS3_ACC_GYRO_R_SIGN_MOT_on_INT2(void *handle, LSM6DS3_ACC_GYRO_INT2_SIGN_MOT_t *value);
+mems_status_t  LSM6DS3_ACC_GYRO_W_SIGN_MOT_on_INT2(void *handle, LSM6DS3_ACC_GYRO_INT2_SIGN_MOT_t newValue);
+mems_status_t LSM6DS3_ACC_GYRO_R_SIGN_MOT_on_INT2(void *handle, LSM6DS3_ACC_GYRO_INT2_SIGN_MOT_t *value);
 
 /*******************************************************************************
 * Register      : INT2_CTRL
@@ -959,8 +959,8 @@ typedef enum
 } LSM6DS3_ACC_GYRO_INT2_PEDO_t;
 
 #define   LSM6DS3_ACC_GYRO_INT2_PEDO_MASK   0x80
-status_t  LSM6DS3_ACC_GYRO_W_PEDO_STEP_on_INT2(void *handle, LSM6DS3_ACC_GYRO_INT2_PEDO_t newValue);
-status_t LSM6DS3_ACC_GYRO_R_PEDO_STEP_on_INT2(void *handle, LSM6DS3_ACC_GYRO_INT2_PEDO_t *value);
+mems_status_t  LSM6DS3_ACC_GYRO_W_PEDO_STEP_on_INT2(void *handle, LSM6DS3_ACC_GYRO_INT2_PEDO_t newValue);
+mems_status_t LSM6DS3_ACC_GYRO_R_PEDO_STEP_on_INT2(void *handle, LSM6DS3_ACC_GYRO_INT2_PEDO_t *value);
 
 /*******************************************************************************
 * Register      : CTRL3_C
@@ -975,8 +975,8 @@ typedef enum
 } LSM6DS3_ACC_GYRO_SW_RESET_t;
 
 #define   LSM6DS3_ACC_GYRO_SW_RESET_MASK    0x01
-status_t  LSM6DS3_ACC_GYRO_W_SW_RESET(void *handle, LSM6DS3_ACC_GYRO_SW_RESET_t newValue);
-status_t LSM6DS3_ACC_GYRO_R_SW_RESET(void *handle, LSM6DS3_ACC_GYRO_SW_RESET_t *value);
+mems_status_t  LSM6DS3_ACC_GYRO_W_SW_RESET(void *handle, LSM6DS3_ACC_GYRO_SW_RESET_t newValue);
+mems_status_t LSM6DS3_ACC_GYRO_R_SW_RESET(void *handle, LSM6DS3_ACC_GYRO_SW_RESET_t *value);
 
 /*******************************************************************************
 * Register      : CTRL3_C
@@ -991,8 +991,8 @@ typedef enum
 } LSM6DS3_ACC_GYRO_BLE_t;
 
 #define   LSM6DS3_ACC_GYRO_BLE_MASK   0x02
-status_t  LSM6DS3_ACC_GYRO_W_BLE(void *handle, LSM6DS3_ACC_GYRO_BLE_t newValue);
-status_t LSM6DS3_ACC_GYRO_R_BLE(void *handle, LSM6DS3_ACC_GYRO_BLE_t *value);
+mems_status_t  LSM6DS3_ACC_GYRO_W_BLE(void *handle, LSM6DS3_ACC_GYRO_BLE_t newValue);
+mems_status_t LSM6DS3_ACC_GYRO_R_BLE(void *handle, LSM6DS3_ACC_GYRO_BLE_t *value);
 
 /*******************************************************************************
 * Register      : CTRL3_C
@@ -1007,8 +1007,8 @@ typedef enum
 } LSM6DS3_ACC_GYRO_IF_INC_t;
 
 #define   LSM6DS3_ACC_GYRO_IF_INC_MASK    0x04
-status_t  LSM6DS3_ACC_GYRO_W_IF_Addr_Incr(void *handle, LSM6DS3_ACC_GYRO_IF_INC_t newValue);
-status_t LSM6DS3_ACC_GYRO_R_IF_Addr_Incr(void *handle, LSM6DS3_ACC_GYRO_IF_INC_t *value);
+mems_status_t  LSM6DS3_ACC_GYRO_W_IF_Addr_Incr(void *handle, LSM6DS3_ACC_GYRO_IF_INC_t newValue);
+mems_status_t LSM6DS3_ACC_GYRO_R_IF_Addr_Incr(void *handle, LSM6DS3_ACC_GYRO_IF_INC_t *value);
 
 /*******************************************************************************
 * Register      : CTRL3_C
@@ -1023,8 +1023,8 @@ typedef enum
 } LSM6DS3_ACC_GYRO_SIM_t;
 
 #define   LSM6DS3_ACC_GYRO_SIM_MASK   0x08
-status_t  LSM6DS3_ACC_GYRO_W_SPI_Mode(void *handle, LSM6DS3_ACC_GYRO_SIM_t newValue);
-status_t LSM6DS3_ACC_GYRO_R_SPI_Mode(void *handle, LSM6DS3_ACC_GYRO_SIM_t *value);
+mems_status_t  LSM6DS3_ACC_GYRO_W_SPI_Mode(void *handle, LSM6DS3_ACC_GYRO_SIM_t newValue);
+mems_status_t LSM6DS3_ACC_GYRO_R_SPI_Mode(void *handle, LSM6DS3_ACC_GYRO_SIM_t *value);
 
 /*******************************************************************************
 * Register      : CTRL3_C
@@ -1039,8 +1039,8 @@ typedef enum
 } LSM6DS3_ACC_GYRO_PP_OD_t;
 
 #define   LSM6DS3_ACC_GYRO_PP_OD_MASK   0x10
-status_t  LSM6DS3_ACC_GYRO_W_PadSel(void *handle, LSM6DS3_ACC_GYRO_PP_OD_t newValue);
-status_t LSM6DS3_ACC_GYRO_R_PadSel(void *handle, LSM6DS3_ACC_GYRO_PP_OD_t *value);
+mems_status_t  LSM6DS3_ACC_GYRO_W_PadSel(void *handle, LSM6DS3_ACC_GYRO_PP_OD_t newValue);
+mems_status_t LSM6DS3_ACC_GYRO_R_PadSel(void *handle, LSM6DS3_ACC_GYRO_PP_OD_t *value);
 
 /*******************************************************************************
 * Register      : CTRL3_C
@@ -1055,8 +1055,8 @@ typedef enum
 } LSM6DS3_ACC_GYRO_INT_ACT_LEVEL_t;
 
 #define   LSM6DS3_ACC_GYRO_INT_ACT_LEVEL_MASK   0x20
-status_t  LSM6DS3_ACC_GYRO_W_INT_ACT_LEVEL(void *handle, LSM6DS3_ACC_GYRO_INT_ACT_LEVEL_t newValue);
-status_t LSM6DS3_ACC_GYRO_R_INT_ACT_LEVEL(void *handle, LSM6DS3_ACC_GYRO_INT_ACT_LEVEL_t *value);
+mems_status_t  LSM6DS3_ACC_GYRO_W_INT_ACT_LEVEL(void *handle, LSM6DS3_ACC_GYRO_INT_ACT_LEVEL_t newValue);
+mems_status_t LSM6DS3_ACC_GYRO_R_INT_ACT_LEVEL(void *handle, LSM6DS3_ACC_GYRO_INT_ACT_LEVEL_t *value);
 
 /*******************************************************************************
 * Register      : CTRL3_C
@@ -1071,8 +1071,8 @@ typedef enum
 } LSM6DS3_ACC_GYRO_BOOT_t;
 
 #define   LSM6DS3_ACC_GYRO_BOOT_MASK    0x80
-status_t  LSM6DS3_ACC_GYRO_W_BOOT(void *handle, LSM6DS3_ACC_GYRO_BOOT_t newValue);
-status_t LSM6DS3_ACC_GYRO_R_BOOT(void *handle, LSM6DS3_ACC_GYRO_BOOT_t *value);
+mems_status_t  LSM6DS3_ACC_GYRO_W_BOOT(void *handle, LSM6DS3_ACC_GYRO_BOOT_t newValue);
+mems_status_t LSM6DS3_ACC_GYRO_R_BOOT(void *handle, LSM6DS3_ACC_GYRO_BOOT_t *value);
 
 /*******************************************************************************
 * Register      : CTRL4_C
@@ -1087,8 +1087,8 @@ typedef enum
 } LSM6DS3_ACC_GYRO_STOP_ON_FTH_t;
 
 #define   LSM6DS3_ACC_GYRO_STOP_ON_FTH_MASK   0x01
-status_t  LSM6DS3_ACC_GYRO_W_STOP_ON_FTH(void *handle, LSM6DS3_ACC_GYRO_STOP_ON_FTH_t newValue);
-status_t LSM6DS3_ACC_GYRO_R_STOP_ON_FTH(void *handle, LSM6DS3_ACC_GYRO_STOP_ON_FTH_t *value);
+mems_status_t  LSM6DS3_ACC_GYRO_W_STOP_ON_FTH(void *handle, LSM6DS3_ACC_GYRO_STOP_ON_FTH_t newValue);
+mems_status_t LSM6DS3_ACC_GYRO_R_STOP_ON_FTH(void *handle, LSM6DS3_ACC_GYRO_STOP_ON_FTH_t *value);
 
 /*******************************************************************************
 * Register      : CTRL4_C
@@ -1103,8 +1103,8 @@ typedef enum
 } LSM6DS3_ACC_GYRO_MODE3_EN_t;
 
 #define   LSM6DS3_ACC_GYRO_MODE3_EN_MASK    0x02
-status_t  LSM6DS3_ACC_GYRO_W_MODE3_Enable(void *handle, LSM6DS3_ACC_GYRO_MODE3_EN_t newValue);
-status_t LSM6DS3_ACC_GYRO_R_MODE3_Enable(void *handle, LSM6DS3_ACC_GYRO_MODE3_EN_t *value);
+mems_status_t  LSM6DS3_ACC_GYRO_W_MODE3_Enable(void *handle, LSM6DS3_ACC_GYRO_MODE3_EN_t newValue);
+mems_status_t LSM6DS3_ACC_GYRO_R_MODE3_Enable(void *handle, LSM6DS3_ACC_GYRO_MODE3_EN_t *value);
 
 /*******************************************************************************
 * Register      : CTRL4_C
@@ -1119,8 +1119,8 @@ typedef enum
 } LSM6DS3_ACC_GYRO_I2C_DISABLE_t;
 
 #define   LSM6DS3_ACC_GYRO_I2C_DISABLE_MASK   0x04
-status_t  LSM6DS3_ACC_GYRO_W_I2C_DISABLE(void *handle, LSM6DS3_ACC_GYRO_I2C_DISABLE_t newValue);
-status_t LSM6DS3_ACC_GYRO_R_I2C_DISABLE(void *handle, LSM6DS3_ACC_GYRO_I2C_DISABLE_t *value);
+mems_status_t  LSM6DS3_ACC_GYRO_W_I2C_DISABLE(void *handle, LSM6DS3_ACC_GYRO_I2C_DISABLE_t newValue);
+mems_status_t LSM6DS3_ACC_GYRO_R_I2C_DISABLE(void *handle, LSM6DS3_ACC_GYRO_I2C_DISABLE_t *value);
 
 /*******************************************************************************
 * Register      : CTRL4_C
@@ -1135,8 +1135,8 @@ typedef enum
 } LSM6DS3_ACC_GYRO_DRDY_MSK_t;
 
 #define   LSM6DS3_ACC_GYRO_DRDY_MSK_MASK    0x08
-status_t  LSM6DS3_ACC_GYRO_W_DRDY_MSK(void *handle, LSM6DS3_ACC_GYRO_DRDY_MSK_t newValue);
-status_t LSM6DS3_ACC_GYRO_R_DRDY_MSK(void *handle, LSM6DS3_ACC_GYRO_DRDY_MSK_t *value);
+mems_status_t  LSM6DS3_ACC_GYRO_W_DRDY_MSK(void *handle, LSM6DS3_ACC_GYRO_DRDY_MSK_t newValue);
+mems_status_t LSM6DS3_ACC_GYRO_R_DRDY_MSK(void *handle, LSM6DS3_ACC_GYRO_DRDY_MSK_t *value);
 
 /*******************************************************************************
 * Register      : CTRL4_C
@@ -1151,8 +1151,8 @@ typedef enum
 } LSM6DS3_ACC_GYRO_FIFO_TEMP_EN_t;
 
 #define   LSM6DS3_ACC_GYRO_FIFO_TEMP_EN_MASK    0x10
-status_t  LSM6DS3_ACC_GYRO_W_FIFO_TEMP_EN(void *handle, LSM6DS3_ACC_GYRO_FIFO_TEMP_EN_t newValue);
-status_t LSM6DS3_ACC_GYRO_R_FIFO_TEMP_EN(void *handle, LSM6DS3_ACC_GYRO_FIFO_TEMP_EN_t *value);
+mems_status_t  LSM6DS3_ACC_GYRO_W_FIFO_TEMP_EN(void *handle, LSM6DS3_ACC_GYRO_FIFO_TEMP_EN_t newValue);
+mems_status_t LSM6DS3_ACC_GYRO_R_FIFO_TEMP_EN(void *handle, LSM6DS3_ACC_GYRO_FIFO_TEMP_EN_t *value);
 
 /*******************************************************************************
 * Register      : CTRL4_C
@@ -1167,8 +1167,8 @@ typedef enum
 } LSM6DS3_ACC_GYRO_INT2_ON_INT1_t;
 
 #define   LSM6DS3_ACC_GYRO_INT2_ON_INT1_MASK    0x20
-status_t  LSM6DS3_ACC_GYRO_W_INT2_ON_INT1(void *handle, LSM6DS3_ACC_GYRO_INT2_ON_INT1_t newValue);
-status_t LSM6DS3_ACC_GYRO_R_INT2_ON_INT1(void *handle, LSM6DS3_ACC_GYRO_INT2_ON_INT1_t *value);
+mems_status_t  LSM6DS3_ACC_GYRO_W_INT2_ON_INT1(void *handle, LSM6DS3_ACC_GYRO_INT2_ON_INT1_t newValue);
+mems_status_t LSM6DS3_ACC_GYRO_R_INT2_ON_INT1(void *handle, LSM6DS3_ACC_GYRO_INT2_ON_INT1_t *value);
 
 /*******************************************************************************
 * Register      : CTRL4_C
@@ -1183,8 +1183,8 @@ typedef enum
 } LSM6DS3_ACC_GYRO_SLEEP_G_t;
 
 #define   LSM6DS3_ACC_GYRO_SLEEP_G_MASK   0x40
-status_t  LSM6DS3_ACC_GYRO_W_SleepMode_G(void *handle, LSM6DS3_ACC_GYRO_SLEEP_G_t newValue);
-status_t LSM6DS3_ACC_GYRO_R_SleepMode_G(void *handle, LSM6DS3_ACC_GYRO_SLEEP_G_t *value);
+mems_status_t  LSM6DS3_ACC_GYRO_W_SleepMode_G(void *handle, LSM6DS3_ACC_GYRO_SLEEP_G_t newValue);
+mems_status_t LSM6DS3_ACC_GYRO_R_SleepMode_G(void *handle, LSM6DS3_ACC_GYRO_SLEEP_G_t *value);
 
 /*******************************************************************************
 * Register      : CTRL4_C
@@ -1199,8 +1199,8 @@ typedef enum
 } LSM6DS3_ACC_GYRO_BW_SCAL_ODR_t;
 
 #define   LSM6DS3_ACC_GYRO_BW_SCAL_ODR_MASK   0x80
-status_t  LSM6DS3_ACC_GYRO_W_BW_Fixed_By_ODR(void *handle, LSM6DS3_ACC_GYRO_BW_SCAL_ODR_t newValue);
-status_t LSM6DS3_ACC_GYRO_R_BW_Fixed_By_ODR(void *handle, LSM6DS3_ACC_GYRO_BW_SCAL_ODR_t *value);
+mems_status_t  LSM6DS3_ACC_GYRO_W_BW_Fixed_By_ODR(void *handle, LSM6DS3_ACC_GYRO_BW_SCAL_ODR_t newValue);
+mems_status_t LSM6DS3_ACC_GYRO_R_BW_Fixed_By_ODR(void *handle, LSM6DS3_ACC_GYRO_BW_SCAL_ODR_t *value);
 
 /*******************************************************************************
 * Register      : CTRL5_C
@@ -1217,8 +1217,8 @@ typedef enum
 } LSM6DS3_ACC_GYRO_ST_XL_t;
 
 #define   LSM6DS3_ACC_GYRO_ST_XL_MASK   0x03
-status_t  LSM6DS3_ACC_GYRO_W_SelfTest_XL(void *handle, LSM6DS3_ACC_GYRO_ST_XL_t newValue);
-status_t LSM6DS3_ACC_GYRO_R_SelfTest_XL(void *handle, LSM6DS3_ACC_GYRO_ST_XL_t *value);
+mems_status_t  LSM6DS3_ACC_GYRO_W_SelfTest_XL(void *handle, LSM6DS3_ACC_GYRO_ST_XL_t newValue);
+mems_status_t LSM6DS3_ACC_GYRO_R_SelfTest_XL(void *handle, LSM6DS3_ACC_GYRO_ST_XL_t *value);
 
 /*******************************************************************************
 * Register      : CTRL5_C
@@ -1235,8 +1235,8 @@ typedef enum
 } LSM6DS3_ACC_GYRO_ST_G_t;
 
 #define   LSM6DS3_ACC_GYRO_ST_G_MASK    0x0C
-status_t  LSM6DS3_ACC_GYRO_W_SelfTest_G(void *handle, LSM6DS3_ACC_GYRO_ST_G_t newValue);
-status_t LSM6DS3_ACC_GYRO_R_SelfTest_G(void *handle, LSM6DS3_ACC_GYRO_ST_G_t *value);
+mems_status_t  LSM6DS3_ACC_GYRO_W_SelfTest_G(void *handle, LSM6DS3_ACC_GYRO_ST_G_t newValue);
+mems_status_t LSM6DS3_ACC_GYRO_R_SelfTest_G(void *handle, LSM6DS3_ACC_GYRO_ST_G_t *value);
 
 /*******************************************************************************
 * Register      : CTRL5_C
@@ -1257,8 +1257,8 @@ typedef enum
 } LSM6DS3_ACC_GYRO_ROUNDING_t;
 
 #define   LSM6DS3_ACC_GYRO_LSM6DS3_ACC_GYRO_ROUNDING_t_MASK   0xE0
-status_t  LSM6DS3_ACC_GYRO_W_CircularBurstMode(void *handle, LSM6DS3_ACC_GYRO_ROUNDING_t newValue);
-status_t LSM6DS3_ACC_GYRO_R_CircularBurstMode(void *handle, LSM6DS3_ACC_GYRO_ROUNDING_t *value);
+mems_status_t  LSM6DS3_ACC_GYRO_W_CircularBurstMode(void *handle, LSM6DS3_ACC_GYRO_ROUNDING_t newValue);
+mems_status_t LSM6DS3_ACC_GYRO_R_CircularBurstMode(void *handle, LSM6DS3_ACC_GYRO_ROUNDING_t *value);
 
 /*******************************************************************************
 * Register      : CTRL6_G
@@ -1273,8 +1273,8 @@ typedef enum
 } LSM6DS3_ACC_GYRO_LP_XL_t;
 
 #define   LSM6DS3_ACC_GYRO_LP_XL_MASK   0x10
-status_t  LSM6DS3_ACC_GYRO_W_LowPower_XL(void *handle, LSM6DS3_ACC_GYRO_LP_XL_t newValue);
-status_t LSM6DS3_ACC_GYRO_R_LowPower_XL(void *handle, LSM6DS3_ACC_GYRO_LP_XL_t *value);
+mems_status_t  LSM6DS3_ACC_GYRO_W_LowPower_XL(void *handle, LSM6DS3_ACC_GYRO_LP_XL_t newValue);
+mems_status_t LSM6DS3_ACC_GYRO_R_LowPower_XL(void *handle, LSM6DS3_ACC_GYRO_LP_XL_t *value);
 
 /*******************************************************************************
 * Register      : CTRL6_G
@@ -1289,8 +1289,8 @@ typedef enum
 } LSM6DS3_ACC_GYRO_DEN_LVL2_EN_t;
 
 #define   LSM6DS3_ACC_GYRO_DEN_LVL2_EN_MASK   0x20
-status_t  LSM6DS3_ACC_GYRO_W_DEN_LVL2_EN(void *handle, LSM6DS3_ACC_GYRO_DEN_LVL2_EN_t newValue);
-status_t LSM6DS3_ACC_GYRO_R_DEN_LVL2_EN(void *handle, LSM6DS3_ACC_GYRO_DEN_LVL2_EN_t *value);
+mems_status_t  LSM6DS3_ACC_GYRO_W_DEN_LVL2_EN(void *handle, LSM6DS3_ACC_GYRO_DEN_LVL2_EN_t newValue);
+mems_status_t LSM6DS3_ACC_GYRO_R_DEN_LVL2_EN(void *handle, LSM6DS3_ACC_GYRO_DEN_LVL2_EN_t *value);
 
 /*******************************************************************************
 * Register      : CTRL6_G
@@ -1305,8 +1305,8 @@ typedef enum
 } LSM6DS3_ACC_GYRO_DEN_LVL_EN_t;
 
 #define   LSM6DS3_ACC_GYRO_DEN_LVL_EN_MASK    0x40
-status_t  LSM6DS3_ACC_GYRO_W_DEN_LVL_EN(void *handle, LSM6DS3_ACC_GYRO_DEN_LVL_EN_t newValue);
-status_t LSM6DS3_ACC_GYRO_R_DEN_LVL_EN(void *handle, LSM6DS3_ACC_GYRO_DEN_LVL_EN_t *value);
+mems_status_t  LSM6DS3_ACC_GYRO_W_DEN_LVL_EN(void *handle, LSM6DS3_ACC_GYRO_DEN_LVL_EN_t newValue);
+mems_status_t LSM6DS3_ACC_GYRO_R_DEN_LVL_EN(void *handle, LSM6DS3_ACC_GYRO_DEN_LVL_EN_t *value);
 
 /*******************************************************************************
 * Register      : CTRL6_G
@@ -1321,8 +1321,8 @@ typedef enum
 } LSM6DS3_ACC_GYRO_DEN_EDGE_EN_t;
 
 #define   LSM6DS3_ACC_GYRO_DEN_EDGE_EN_MASK   0x80
-status_t  LSM6DS3_ACC_GYRO_W_DEN_EDGE_EN(void *handle, LSM6DS3_ACC_GYRO_DEN_EDGE_EN_t newValue);
-status_t LSM6DS3_ACC_GYRO_R_DEN_EDGE_EN(void *handle, LSM6DS3_ACC_GYRO_DEN_EDGE_EN_t *value);
+mems_status_t  LSM6DS3_ACC_GYRO_W_DEN_EDGE_EN(void *handle, LSM6DS3_ACC_GYRO_DEN_EDGE_EN_t newValue);
+mems_status_t LSM6DS3_ACC_GYRO_R_DEN_EDGE_EN(void *handle, LSM6DS3_ACC_GYRO_DEN_EDGE_EN_t *value);
 
 /*******************************************************************************
 * Register      : CTRL7_G
@@ -1339,8 +1339,8 @@ typedef enum
 } LSM6DS3_ACC_GYRO_HPCF_G_t;
 
 #define   LSM6DS3_ACC_GYRO_HPCF_G_MASK    0x30
-status_t  LSM6DS3_ACC_GYRO_W_HPCF_G(void *handle, LSM6DS3_ACC_GYRO_HPCF_G_t newValue);
-status_t LSM6DS3_ACC_GYRO_R_HPCF_G(void *handle, LSM6DS3_ACC_GYRO_HPCF_G_t *value);
+mems_status_t  LSM6DS3_ACC_GYRO_W_HPCF_G(void *handle, LSM6DS3_ACC_GYRO_HPCF_G_t newValue);
+mems_status_t LSM6DS3_ACC_GYRO_R_HPCF_G(void *handle, LSM6DS3_ACC_GYRO_HPCF_G_t *value);
 
 /*******************************************************************************
 * Register      : CTRL7_G
@@ -1355,8 +1355,8 @@ typedef enum
 } LSM6DS3_ACC_GYRO_HP_EN_t;
 
 #define   LSM6DS3_ACC_GYRO_HP_EN_MASK   0x40
-status_t  LSM6DS3_ACC_GYRO_W_HPFilter_En(void *handle, LSM6DS3_ACC_GYRO_HP_EN_t newValue);
-status_t LSM6DS3_ACC_GYRO_R_HPFilter_En(void *handle, LSM6DS3_ACC_GYRO_HP_EN_t *value);
+mems_status_t  LSM6DS3_ACC_GYRO_W_HPFilter_En(void *handle, LSM6DS3_ACC_GYRO_HP_EN_t newValue);
+mems_status_t LSM6DS3_ACC_GYRO_R_HPFilter_En(void *handle, LSM6DS3_ACC_GYRO_HP_EN_t *value);
 
 /*******************************************************************************
 * Register      : CTRL7_G
@@ -1371,8 +1371,8 @@ typedef enum
 } LSM6DS3_ACC_GYRO_LP_EN_t;
 
 #define   LSM6DS3_ACC_GYRO_LP_EN_MASK   0x80
-status_t  LSM6DS3_ACC_GYRO_W_LP_Mode(void *handle, LSM6DS3_ACC_GYRO_LP_EN_t newValue);
-status_t LSM6DS3_ACC_GYRO_R_LP_Mode(void *handle, LSM6DS3_ACC_GYRO_LP_EN_t *value);
+mems_status_t  LSM6DS3_ACC_GYRO_W_LP_Mode(void *handle, LSM6DS3_ACC_GYRO_LP_EN_t newValue);
+mems_status_t LSM6DS3_ACC_GYRO_R_LP_Mode(void *handle, LSM6DS3_ACC_GYRO_LP_EN_t *value);
 
 /*******************************************************************************
 * Register      : CTRL7_G
@@ -1387,8 +1387,8 @@ typedef enum
 } LSM6DS3_ACC_GYRO_ROUNDING_STATUS_t;
 
 #define   LSM6DS3_ACC_GYRO_ROUNDING_STATUS_MASK   0x04
-status_t  LSM6DS3_ACC_GYRO_W_ROUNDING_STATUS(void *handle, LSM6DS3_ACC_GYRO_ROUNDING_STATUS_t newValue);
-status_t LSM6DS3_ACC_GYRO_R_ROUNDING_STATUS(void *handle, LSM6DS3_ACC_GYRO_ROUNDING_STATUS_t *value);
+mems_status_t  LSM6DS3_ACC_GYRO_W_ROUNDING_STATUS(void *handle, LSM6DS3_ACC_GYRO_ROUNDING_STATUS_t newValue);
+mems_status_t LSM6DS3_ACC_GYRO_R_ROUNDING_STATUS(void *handle, LSM6DS3_ACC_GYRO_ROUNDING_STATUS_t *value);
 
 /*******************************************************************************
 * Register      : CTRL7_G
@@ -1403,8 +1403,8 @@ typedef enum
 } LSM6DS3_ACC_GYRO_HP_G_RST_t;
 
 #define   LSM6DS3_ACC_GYRO_HP_G_RST_MASK    0x08
-status_t  LSM6DS3_ACC_GYRO_W_HP_G_RST(void *handle, LSM6DS3_ACC_GYRO_HP_G_RST_t newValue);
-status_t LSM6DS3_ACC_GYRO_R_HP_G_RST(void *handle, LSM6DS3_ACC_GYRO_HP_G_RST_t *value);
+mems_status_t  LSM6DS3_ACC_GYRO_W_HP_G_RST(void *handle, LSM6DS3_ACC_GYRO_HP_G_RST_t newValue);
+mems_status_t LSM6DS3_ACC_GYRO_R_HP_G_RST(void *handle, LSM6DS3_ACC_GYRO_HP_G_RST_t *value);
 
 /*******************************************************************************
 * Register      : CTRL8_XL
@@ -1419,8 +1419,8 @@ typedef enum
 } LSM6DS3_ACC_GYRO_LOW_PASS_ON_6D_t;
 
 #define   LSM6DS3_ACC_GYRO_LOW_PASS_ON_6D_MASK    0x01
-status_t  LSM6DS3_ACC_GYRO_W_LOW_PASS_ON_6D(void *handle, LSM6DS3_ACC_GYRO_LOW_PASS_ON_6D_t newValue);
-status_t LSM6DS3_ACC_GYRO_R_LOW_PASS_ON_6D(void *handle, LSM6DS3_ACC_GYRO_LOW_PASS_ON_6D_t *value);
+mems_status_t  LSM6DS3_ACC_GYRO_W_LOW_PASS_ON_6D(void *handle, LSM6DS3_ACC_GYRO_LOW_PASS_ON_6D_t newValue);
+mems_status_t LSM6DS3_ACC_GYRO_R_LOW_PASS_ON_6D(void *handle, LSM6DS3_ACC_GYRO_LOW_PASS_ON_6D_t *value);
 
 /*******************************************************************************
 * Register      : CTRL8_XL
@@ -1435,8 +1435,8 @@ typedef enum
 } LSM6DS3_ACC_GYRO_HP_SLOPE_XL_t;
 
 #define   LSM6DS3_ACC_GYRO_HP_SLOPE_XL_MASK   0x04
-status_t  LSM6DS3_ACC_GYRO_W_HP_SLOPE_XL(void *handle, LSM6DS3_ACC_GYRO_HP_SLOPE_XL_t newValue);
-status_t LSM6DS3_ACC_GYRO_R_HP_SLOPE_XL(void *handle, LSM6DS3_ACC_GYRO_HP_SLOPE_XL_t *value);
+mems_status_t  LSM6DS3_ACC_GYRO_W_HP_SLOPE_XL(void *handle, LSM6DS3_ACC_GYRO_HP_SLOPE_XL_t newValue);
+mems_status_t LSM6DS3_ACC_GYRO_R_HP_SLOPE_XL(void *handle, LSM6DS3_ACC_GYRO_HP_SLOPE_XL_t *value);
 
 /*******************************************************************************
 * Register      : CTRL8_XL
@@ -1451,8 +1451,8 @@ typedef enum
 } LSM6DS3_ACC_GYRO_LPF2_XL_t;
 
 #define   LSM6DS3_ACC_GYRO_LPF2_XL_MASK   0x80
-status_t  LSM6DS3_ACC_GYRO_W_LPF2_XL(void *handle, LSM6DS3_ACC_GYRO_LPF2_XL_t newValue);
-status_t LSM6DS3_ACC_GYRO_R_LPF2_XL(void *handle, LSM6DS3_ACC_GYRO_LPF2_XL_t *value);
+mems_status_t  LSM6DS3_ACC_GYRO_W_LPF2_XL(void *handle, LSM6DS3_ACC_GYRO_LPF2_XL_t newValue);
+mems_status_t LSM6DS3_ACC_GYRO_R_LPF2_XL(void *handle, LSM6DS3_ACC_GYRO_LPF2_XL_t *value);
 
 /*******************************************************************************
 * Register      : CTRL8_XL
@@ -1469,8 +1469,8 @@ typedef enum
 } LSM6DS3_ACC_GYRO_HPCF_XL_t;
 
 #define   LSM6DS3_ACC_GYRO_HPCF_XL_MASK   0x60
-status_t  LSM6DS3_ACC_GYRO_W_HPCF_XL(void *handle, LSM6DS3_ACC_GYRO_HPCF_XL_t newValue);
-status_t LSM6DS3_ACC_GYRO_R_HPCF_XL(void *handle, LSM6DS3_ACC_GYRO_HPCF_XL_t *value);
+mems_status_t  LSM6DS3_ACC_GYRO_W_HPCF_XL(void *handle, LSM6DS3_ACC_GYRO_HPCF_XL_t newValue);
+mems_status_t LSM6DS3_ACC_GYRO_R_HPCF_XL(void *handle, LSM6DS3_ACC_GYRO_HPCF_XL_t *value);
 
 /*******************************************************************************
 * Register      : CTRL9_XL
@@ -1485,8 +1485,8 @@ typedef enum
 } LSM6DS3_ACC_GYRO_XEN_XL_t;
 
 #define   LSM6DS3_ACC_GYRO_XEN_XL_MASK    0x08
-status_t  LSM6DS3_ACC_GYRO_W_XEN_XL(void *handle, LSM6DS3_ACC_GYRO_XEN_XL_t newValue);
-status_t LSM6DS3_ACC_GYRO_R_XEN_XL(void *handle, LSM6DS3_ACC_GYRO_XEN_XL_t *value);
+mems_status_t  LSM6DS3_ACC_GYRO_W_XEN_XL(void *handle, LSM6DS3_ACC_GYRO_XEN_XL_t newValue);
+mems_status_t LSM6DS3_ACC_GYRO_R_XEN_XL(void *handle, LSM6DS3_ACC_GYRO_XEN_XL_t *value);
 
 /*******************************************************************************
 * Register      : CTRL9_XL
@@ -1501,8 +1501,8 @@ typedef enum
 } LSM6DS3_ACC_GYRO_YEN_XL_t;
 
 #define   LSM6DS3_ACC_GYRO_YEN_XL_MASK    0x10
-status_t  LSM6DS3_ACC_GYRO_W_YEN_XL(void *handle, LSM6DS3_ACC_GYRO_YEN_XL_t newValue);
-status_t LSM6DS3_ACC_GYRO_R_YEN_XL(void *handle, LSM6DS3_ACC_GYRO_YEN_XL_t *value);
+mems_status_t  LSM6DS3_ACC_GYRO_W_YEN_XL(void *handle, LSM6DS3_ACC_GYRO_YEN_XL_t newValue);
+mems_status_t LSM6DS3_ACC_GYRO_R_YEN_XL(void *handle, LSM6DS3_ACC_GYRO_YEN_XL_t *value);
 
 /*******************************************************************************
 * Register      : CTRL9_XL
@@ -1517,8 +1517,8 @@ typedef enum
 } LSM6DS3_ACC_GYRO_ZEN_XL_t;
 
 #define   LSM6DS3_ACC_GYRO_ZEN_XL_MASK    0x20
-status_t  LSM6DS3_ACC_GYRO_W_ZEN_XL(void *handle, LSM6DS3_ACC_GYRO_ZEN_XL_t newValue);
-status_t LSM6DS3_ACC_GYRO_R_ZEN_XL(void *handle, LSM6DS3_ACC_GYRO_ZEN_XL_t *value);
+mems_status_t  LSM6DS3_ACC_GYRO_W_ZEN_XL(void *handle, LSM6DS3_ACC_GYRO_ZEN_XL_t newValue);
+mems_status_t LSM6DS3_ACC_GYRO_R_ZEN_XL(void *handle, LSM6DS3_ACC_GYRO_ZEN_XL_t *value);
 
 /*******************************************************************************
 * Register      : CTRL9_XL
@@ -1533,8 +1533,8 @@ typedef enum
 } LSM6DS3_ACC_GYRO_SOFT_t;
 
 #define   LSM6DS3_ACC_GYRO_SOFT_MASK    0x04
-status_t  LSM6DS3_ACC_GYRO_W_SOFT(void *handle, LSM6DS3_ACC_GYRO_SOFT_t newValue);
-status_t LSM6DS3_ACC_GYRO_R_SOFT(void *handle, LSM6DS3_ACC_GYRO_SOFT_t *value);
+mems_status_t  LSM6DS3_ACC_GYRO_W_SOFT(void *handle, LSM6DS3_ACC_GYRO_SOFT_t newValue);
+mems_status_t LSM6DS3_ACC_GYRO_R_SOFT(void *handle, LSM6DS3_ACC_GYRO_SOFT_t *value);
 
 /*******************************************************************************
 * Register      : CTRL10_C
@@ -1549,8 +1549,8 @@ typedef enum
 } LSM6DS3_ACC_GYRO_SIGN_MOTION_EN_t;
 
 #define   LSM6DS3_ACC_GYRO_SIGN_MOTION_EN_MASK    0x01
-status_t  LSM6DS3_ACC_GYRO_W_SignifcantMotion(void *handle, LSM6DS3_ACC_GYRO_SIGN_MOTION_EN_t newValue);
-status_t LSM6DS3_ACC_GYRO_R_SignifcantMotion(void *handle, LSM6DS3_ACC_GYRO_SIGN_MOTION_EN_t *value);
+mems_status_t  LSM6DS3_ACC_GYRO_W_SignifcantMotion(void *handle, LSM6DS3_ACC_GYRO_SIGN_MOTION_EN_t newValue);
+mems_status_t LSM6DS3_ACC_GYRO_R_SignifcantMotion(void *handle, LSM6DS3_ACC_GYRO_SIGN_MOTION_EN_t *value);
 
 /*******************************************************************************
 * Register      : CTRL10_C
@@ -1565,8 +1565,8 @@ typedef enum
 } LSM6DS3_ACC_GYRO_PEDO_RST_STEP_t;
 
 #define   LSM6DS3_ACC_GYRO_PEDO_RST_STEP_MASK   0x02
-status_t  LSM6DS3_ACC_GYRO_W_PedoStepReset(void *handle, LSM6DS3_ACC_GYRO_PEDO_RST_STEP_t newValue);
-status_t LSM6DS3_ACC_GYRO_R_PedoStepReset(void *handle, LSM6DS3_ACC_GYRO_PEDO_RST_STEP_t *value);
+mems_status_t  LSM6DS3_ACC_GYRO_W_PedoStepReset(void *handle, LSM6DS3_ACC_GYRO_PEDO_RST_STEP_t newValue);
+mems_status_t LSM6DS3_ACC_GYRO_R_PedoStepReset(void *handle, LSM6DS3_ACC_GYRO_PEDO_RST_STEP_t *value);
 
 /*******************************************************************************
 * Register      : CTRL10_C
@@ -1581,8 +1581,8 @@ typedef enum
 } LSM6DS3_ACC_GYRO_XEN_G_t;
 
 #define   LSM6DS3_ACC_GYRO_XEN_G_MASK   0x08
-status_t  LSM6DS3_ACC_GYRO_W_XEN_G(void *handle, LSM6DS3_ACC_GYRO_XEN_G_t newValue);
-status_t LSM6DS3_ACC_GYRO_R_XEN_G(void *handle, LSM6DS3_ACC_GYRO_XEN_G_t *value);
+mems_status_t  LSM6DS3_ACC_GYRO_W_XEN_G(void *handle, LSM6DS3_ACC_GYRO_XEN_G_t newValue);
+mems_status_t LSM6DS3_ACC_GYRO_R_XEN_G(void *handle, LSM6DS3_ACC_GYRO_XEN_G_t *value);
 
 /*******************************************************************************
 * Register      : CTRL10_C
@@ -1597,8 +1597,8 @@ typedef enum
 } LSM6DS3_ACC_GYRO_YEN_G_t;
 
 #define   LSM6DS3_ACC_GYRO_YEN_G_MASK   0x10
-status_t  LSM6DS3_ACC_GYRO_W_YEN_G(void *handle, LSM6DS3_ACC_GYRO_YEN_G_t newValue);
-status_t LSM6DS3_ACC_GYRO_R_YEN_G(void *handle, LSM6DS3_ACC_GYRO_YEN_G_t *value);
+mems_status_t  LSM6DS3_ACC_GYRO_W_YEN_G(void *handle, LSM6DS3_ACC_GYRO_YEN_G_t newValue);
+mems_status_t LSM6DS3_ACC_GYRO_R_YEN_G(void *handle, LSM6DS3_ACC_GYRO_YEN_G_t *value);
 
 /*******************************************************************************
 * Register      : CTRL10_C
@@ -1613,8 +1613,8 @@ typedef enum
 } LSM6DS3_ACC_GYRO_ZEN_G_t;
 
 #define   LSM6DS3_ACC_GYRO_ZEN_G_MASK   0x20
-status_t  LSM6DS3_ACC_GYRO_W_ZEN_G(void *handle, LSM6DS3_ACC_GYRO_ZEN_G_t newValue);
-status_t LSM6DS3_ACC_GYRO_R_ZEN_G(void *handle, LSM6DS3_ACC_GYRO_ZEN_G_t *value);
+mems_status_t  LSM6DS3_ACC_GYRO_W_ZEN_G(void *handle, LSM6DS3_ACC_GYRO_ZEN_G_t newValue);
+mems_status_t LSM6DS3_ACC_GYRO_R_ZEN_G(void *handle, LSM6DS3_ACC_GYRO_ZEN_G_t *value);
 
 /*******************************************************************************
 * Register      : CTRL10_C
@@ -1629,8 +1629,8 @@ typedef enum
 } LSM6DS3_ACC_GYRO_FUNC_EN_t;
 
 #define   LSM6DS3_ACC_GYRO_FUNC_EN_MASK   0x04
-status_t  LSM6DS3_ACC_GYRO_W_FUNC_EN(void *handle, LSM6DS3_ACC_GYRO_FUNC_EN_t newValue);
-status_t LSM6DS3_ACC_GYRO_R_FUNC_EN(void *handle, LSM6DS3_ACC_GYRO_FUNC_EN_t *value);
+mems_status_t  LSM6DS3_ACC_GYRO_W_FUNC_EN(void *handle, LSM6DS3_ACC_GYRO_FUNC_EN_t newValue);
+mems_status_t LSM6DS3_ACC_GYRO_R_FUNC_EN(void *handle, LSM6DS3_ACC_GYRO_FUNC_EN_t *value);
 
 /*******************************************************************************
 * Register      : MASTER_CONFIG
@@ -1645,8 +1645,8 @@ typedef enum
 } LSM6DS3_ACC_GYRO_MASTER_ON_t;
 
 #define   LSM6DS3_ACC_GYRO_MASTER_ON_MASK   0x01
-status_t  LSM6DS3_ACC_GYRO_W_I2C_MASTER_Enable(void *handle, LSM6DS3_ACC_GYRO_MASTER_ON_t newValue);
-status_t LSM6DS3_ACC_GYRO_R_I2C_MASTER_Enable(void *handle, LSM6DS3_ACC_GYRO_MASTER_ON_t *value);
+mems_status_t  LSM6DS3_ACC_GYRO_W_I2C_MASTER_Enable(void *handle, LSM6DS3_ACC_GYRO_MASTER_ON_t newValue);
+mems_status_t LSM6DS3_ACC_GYRO_R_I2C_MASTER_Enable(void *handle, LSM6DS3_ACC_GYRO_MASTER_ON_t *value);
 
 /*******************************************************************************
 * Register      : MASTER_CONFIG
@@ -1661,8 +1661,8 @@ typedef enum
 } LSM6DS3_ACC_GYRO_IRON_EN_t;
 
 #define   LSM6DS3_ACC_GYRO_IRON_EN_MASK   0x02
-status_t  LSM6DS3_ACC_GYRO_W_IronCorrection_EN(void *handle, LSM6DS3_ACC_GYRO_IRON_EN_t newValue);
-status_t LSM6DS3_ACC_GYRO_R_IronCorrection_EN(void *handle, LSM6DS3_ACC_GYRO_IRON_EN_t *value);
+mems_status_t  LSM6DS3_ACC_GYRO_W_IronCorrection_EN(void *handle, LSM6DS3_ACC_GYRO_IRON_EN_t newValue);
+mems_status_t LSM6DS3_ACC_GYRO_R_IronCorrection_EN(void *handle, LSM6DS3_ACC_GYRO_IRON_EN_t *value);
 
 /*******************************************************************************
 * Register      : MASTER_CONFIG
@@ -1677,8 +1677,8 @@ typedef enum
 } LSM6DS3_ACC_GYRO_PASS_THRU_MODE_t;
 
 #define   LSM6DS3_ACC_GYRO_PASS_THRU_MODE_MASK    0x04
-status_t  LSM6DS3_ACC_GYRO_W_PASS_THRU_MODE(void *handle, LSM6DS3_ACC_GYRO_PASS_THRU_MODE_t newValue);
-status_t LSM6DS3_ACC_GYRO_R_PASS_THRU_MODE(void *handle, LSM6DS3_ACC_GYRO_PASS_THRU_MODE_t *value);
+mems_status_t  LSM6DS3_ACC_GYRO_W_PASS_THRU_MODE(void *handle, LSM6DS3_ACC_GYRO_PASS_THRU_MODE_t newValue);
+mems_status_t LSM6DS3_ACC_GYRO_R_PASS_THRU_MODE(void *handle, LSM6DS3_ACC_GYRO_PASS_THRU_MODE_t *value);
 
 /*******************************************************************************
 * Register      : MASTER_CONFIG
@@ -1693,8 +1693,8 @@ typedef enum
 } LSM6DS3_ACC_GYRO_PULL_UP_EN_t;
 
 #define   LSM6DS3_ACC_GYRO_PULL_UP_EN_MASK    0x08
-status_t  LSM6DS3_ACC_GYRO_W_PULL_UP_EN(void *handle, LSM6DS3_ACC_GYRO_PULL_UP_EN_t newValue);
-status_t LSM6DS3_ACC_GYRO_R_PULL_UP_EN(void *handle, LSM6DS3_ACC_GYRO_PULL_UP_EN_t *value);
+mems_status_t  LSM6DS3_ACC_GYRO_W_PULL_UP_EN(void *handle, LSM6DS3_ACC_GYRO_PULL_UP_EN_t newValue);
+mems_status_t LSM6DS3_ACC_GYRO_R_PULL_UP_EN(void *handle, LSM6DS3_ACC_GYRO_PULL_UP_EN_t *value);
 
 /*******************************************************************************
 * Register      : MASTER_CONFIG
@@ -1709,8 +1709,8 @@ typedef enum
 } LSM6DS3_ACC_GYRO_START_CONFIG_t;
 
 #define   LSM6DS3_ACC_GYRO_START_CONFIG_MASK    0x10
-status_t  LSM6DS3_ACC_GYRO_W_SensorHUB_Trigger_Sel(void *handle, LSM6DS3_ACC_GYRO_START_CONFIG_t newValue);
-status_t LSM6DS3_ACC_GYRO_R_SensorHUB_Trigger_Sel(void *handle, LSM6DS3_ACC_GYRO_START_CONFIG_t *value);
+mems_status_t  LSM6DS3_ACC_GYRO_W_SensorHUB_Trigger_Sel(void *handle, LSM6DS3_ACC_GYRO_START_CONFIG_t newValue);
+mems_status_t LSM6DS3_ACC_GYRO_R_SensorHUB_Trigger_Sel(void *handle, LSM6DS3_ACC_GYRO_START_CONFIG_t *value);
 
 /*******************************************************************************
 * Register      : MASTER_CONFIG
@@ -1725,8 +1725,8 @@ typedef enum
 } LSM6DS3_ACC_GYRO_DATA_VAL_SEL_FIFO_t;
 
 #define   LSM6DS3_ACC_GYRO_DATA_VAL_SEL_FIFO_MASK   0x40
-status_t  LSM6DS3_ACC_GYRO_W_DATA_VAL_SEL_FIFO(void *handle, LSM6DS3_ACC_GYRO_DATA_VAL_SEL_FIFO_t newValue);
-status_t LSM6DS3_ACC_GYRO_R_DATA_VAL_SEL_FIFO(void *handle, LSM6DS3_ACC_GYRO_DATA_VAL_SEL_FIFO_t *value);
+mems_status_t  LSM6DS3_ACC_GYRO_W_DATA_VAL_SEL_FIFO(void *handle, LSM6DS3_ACC_GYRO_DATA_VAL_SEL_FIFO_t newValue);
+mems_status_t LSM6DS3_ACC_GYRO_R_DATA_VAL_SEL_FIFO(void *handle, LSM6DS3_ACC_GYRO_DATA_VAL_SEL_FIFO_t *value);
 
 /*******************************************************************************
 * Register      : MASTER_CONFIG
@@ -1741,8 +1741,8 @@ typedef enum
 } LSM6DS3_ACC_GYRO_DRDY_ON_INT1_t;
 
 #define   LSM6DS3_ACC_GYRO_DRDY_ON_INT1_MASK    0x80
-status_t  LSM6DS3_ACC_GYRO_W_DRDY_ON_INT1(void *handle, LSM6DS3_ACC_GYRO_DRDY_ON_INT1_t newValue);
-status_t LSM6DS3_ACC_GYRO_R_DRDY_ON_INT1(void *handle, LSM6DS3_ACC_GYRO_DRDY_ON_INT1_t *value);
+mems_status_t  LSM6DS3_ACC_GYRO_W_DRDY_ON_INT1(void *handle, LSM6DS3_ACC_GYRO_DRDY_ON_INT1_t newValue);
+mems_status_t LSM6DS3_ACC_GYRO_R_DRDY_ON_INT1(void *handle, LSM6DS3_ACC_GYRO_DRDY_ON_INT1_t *value);
 
 /*******************************************************************************
 * Register      : WAKE_UP_SRC
@@ -1757,7 +1757,7 @@ typedef enum
 } LSM6DS3_ACC_GYRO_Z_WU_t;
 
 #define   LSM6DS3_ACC_GYRO_Z_WU_MASK    0x01
-status_t LSM6DS3_ACC_GYRO_R_Z_WU(void *handle, LSM6DS3_ACC_GYRO_Z_WU_t *value);
+mems_status_t LSM6DS3_ACC_GYRO_R_Z_WU(void *handle, LSM6DS3_ACC_GYRO_Z_WU_t *value);
 
 /*******************************************************************************
 * Register      : WAKE_UP_SRC
@@ -1772,7 +1772,7 @@ typedef enum
 } LSM6DS3_ACC_GYRO_Y_WU_t;
 
 #define   LSM6DS3_ACC_GYRO_Y_WU_MASK    0x02
-status_t LSM6DS3_ACC_GYRO_R_Y_WU(void *handle, LSM6DS3_ACC_GYRO_Y_WU_t *value);
+mems_status_t LSM6DS3_ACC_GYRO_R_Y_WU(void *handle, LSM6DS3_ACC_GYRO_Y_WU_t *value);
 
 /*******************************************************************************
 * Register      : WAKE_UP_SRC
@@ -1787,7 +1787,7 @@ typedef enum
 } LSM6DS3_ACC_GYRO_X_WU_t;
 
 #define   LSM6DS3_ACC_GYRO_X_WU_MASK    0x04
-status_t LSM6DS3_ACC_GYRO_R_X_WU(void *handle, LSM6DS3_ACC_GYRO_X_WU_t *value);
+mems_status_t LSM6DS3_ACC_GYRO_R_X_WU(void *handle, LSM6DS3_ACC_GYRO_X_WU_t *value);
 
 /*******************************************************************************
 * Register      : WAKE_UP_SRC
@@ -1802,7 +1802,7 @@ typedef enum
 } LSM6DS3_ACC_GYRO_WU_EV_STATUS_t;
 
 #define   LSM6DS3_ACC_GYRO_WU_EV_STATUS_MASK    0x08
-status_t LSM6DS3_ACC_GYRO_R_WU_EV_STATUS(void *handle, LSM6DS3_ACC_GYRO_WU_EV_STATUS_t *value);
+mems_status_t LSM6DS3_ACC_GYRO_R_WU_EV_STATUS(void *handle, LSM6DS3_ACC_GYRO_WU_EV_STATUS_t *value);
 
 /*******************************************************************************
 * Register      : WAKE_UP_SRC
@@ -1817,7 +1817,7 @@ typedef enum
 } LSM6DS3_ACC_GYRO_SLEEP_EV_STATUS_t;
 
 #define   LSM6DS3_ACC_GYRO_SLEEP_EV_STATUS_MASK   0x10
-status_t LSM6DS3_ACC_GYRO_R_SLEEP_EV_STATUS(void *handle, LSM6DS3_ACC_GYRO_SLEEP_EV_STATUS_t *value);
+mems_status_t LSM6DS3_ACC_GYRO_R_SLEEP_EV_STATUS(void *handle, LSM6DS3_ACC_GYRO_SLEEP_EV_STATUS_t *value);
 
 /*******************************************************************************
 * Register      : WAKE_UP_SRC
@@ -1832,7 +1832,7 @@ typedef enum
 } LSM6DS3_ACC_GYRO_FF_EV_STATUS_t;
 
 #define   LSM6DS3_ACC_GYRO_FF_EV_STATUS_MASK    0x20
-status_t LSM6DS3_ACC_GYRO_R_FF_EV_STATUS(void *handle, LSM6DS3_ACC_GYRO_FF_EV_STATUS_t *value);
+mems_status_t LSM6DS3_ACC_GYRO_R_FF_EV_STATUS(void *handle, LSM6DS3_ACC_GYRO_FF_EV_STATUS_t *value);
 
 /*******************************************************************************
 * Register      : TAP_SRC
@@ -1847,7 +1847,7 @@ typedef enum
 } LSM6DS3_ACC_GYRO_Z_TAP_t;
 
 #define   LSM6DS3_ACC_GYRO_Z_TAP_MASK   0x01
-status_t LSM6DS3_ACC_GYRO_R_Z_TAP(void *handle, LSM6DS3_ACC_GYRO_Z_TAP_t *value);
+mems_status_t LSM6DS3_ACC_GYRO_R_Z_TAP(void *handle, LSM6DS3_ACC_GYRO_Z_TAP_t *value);
 
 /*******************************************************************************
 * Register      : TAP_SRC
@@ -1862,7 +1862,7 @@ typedef enum
 } LSM6DS3_ACC_GYRO_Y_TAP_t;
 
 #define   LSM6DS3_ACC_GYRO_Y_TAP_MASK   0x02
-status_t LSM6DS3_ACC_GYRO_R_Y_TAP(void *handle, LSM6DS3_ACC_GYRO_Y_TAP_t *value);
+mems_status_t LSM6DS3_ACC_GYRO_R_Y_TAP(void *handle, LSM6DS3_ACC_GYRO_Y_TAP_t *value);
 
 /*******************************************************************************
 * Register      : TAP_SRC
@@ -1877,7 +1877,7 @@ typedef enum
 } LSM6DS3_ACC_GYRO_X_TAP_t;
 
 #define   LSM6DS3_ACC_GYRO_X_TAP_MASK   0x04
-status_t LSM6DS3_ACC_GYRO_R_X_TAP(void *handle, LSM6DS3_ACC_GYRO_X_TAP_t *value);
+mems_status_t LSM6DS3_ACC_GYRO_R_X_TAP(void *handle, LSM6DS3_ACC_GYRO_X_TAP_t *value);
 
 /*******************************************************************************
 * Register      : TAP_SRC
@@ -1892,7 +1892,7 @@ typedef enum
 } LSM6DS3_ACC_GYRO_TAP_SIGN_t;
 
 #define   LSM6DS3_ACC_GYRO_TAP_SIGN_MASK    0x08
-status_t LSM6DS3_ACC_GYRO_R_TAP_SIGN(void *handle, LSM6DS3_ACC_GYRO_TAP_SIGN_t *value);
+mems_status_t LSM6DS3_ACC_GYRO_R_TAP_SIGN(void *handle, LSM6DS3_ACC_GYRO_TAP_SIGN_t *value);
 
 /*******************************************************************************
 * Register      : TAP_SRC
@@ -1907,7 +1907,7 @@ typedef enum
 } LSM6DS3_ACC_GYRO_DOUBLE_TAP_EV_STATUS_t;
 
 #define   LSM6DS3_ACC_GYRO_DOUBLE_TAP_EV_STATUS_MASK    0x10
-status_t LSM6DS3_ACC_GYRO_R_DOUBLE_TAP_EV_STATUS(void *handle, LSM6DS3_ACC_GYRO_DOUBLE_TAP_EV_STATUS_t *value);
+mems_status_t LSM6DS3_ACC_GYRO_R_DOUBLE_TAP_EV_STATUS(void *handle, LSM6DS3_ACC_GYRO_DOUBLE_TAP_EV_STATUS_t *value);
 
 /*******************************************************************************
 * Register      : TAP_SRC
@@ -1922,7 +1922,7 @@ typedef enum
 } LSM6DS3_ACC_GYRO_SINGLE_TAP_EV_STATUS_t;
 
 #define   LSM6DS3_ACC_GYRO_SINGLE_TAP_EV_STATUS_MASK    0x20
-status_t LSM6DS3_ACC_GYRO_R_SINGLE_TAP_EV_STATUS(void *handle, LSM6DS3_ACC_GYRO_SINGLE_TAP_EV_STATUS_t *value);
+mems_status_t LSM6DS3_ACC_GYRO_R_SINGLE_TAP_EV_STATUS(void *handle, LSM6DS3_ACC_GYRO_SINGLE_TAP_EV_STATUS_t *value);
 
 /*******************************************************************************
 * Register      : TAP_SRC
@@ -1937,7 +1937,7 @@ typedef enum
 } LSM6DS3_ACC_GYRO_TAP_EV_STATUS_t;
 
 #define   LSM6DS3_ACC_GYRO_TAP_EV_STATUS_MASK   0x40
-status_t LSM6DS3_ACC_GYRO_R_TAP_EV_STATUS(void *handle, LSM6DS3_ACC_GYRO_TAP_EV_STATUS_t *value);
+mems_status_t LSM6DS3_ACC_GYRO_R_TAP_EV_STATUS(void *handle, LSM6DS3_ACC_GYRO_TAP_EV_STATUS_t *value);
 
 /*******************************************************************************
 * Register      : D6D_SRC
@@ -1952,7 +1952,7 @@ typedef enum
 } LSM6DS3_ACC_GYRO_DSD_XL_t;
 
 #define   LSM6DS3_ACC_GYRO_DSD_XL_MASK    0x01
-status_t LSM6DS3_ACC_GYRO_R_DSD_XL(void *handle, LSM6DS3_ACC_GYRO_DSD_XL_t *value);
+mems_status_t LSM6DS3_ACC_GYRO_R_DSD_XL(void *handle, LSM6DS3_ACC_GYRO_DSD_XL_t *value);
 
 /*******************************************************************************
 * Register      : D6D_SRC
@@ -1967,7 +1967,7 @@ typedef enum
 } LSM6DS3_ACC_GYRO_DSD_XH_t;
 
 #define   LSM6DS3_ACC_GYRO_DSD_XH_MASK    0x02
-status_t LSM6DS3_ACC_GYRO_R_DSD_XH(void *handle, LSM6DS3_ACC_GYRO_DSD_XH_t *value);
+mems_status_t LSM6DS3_ACC_GYRO_R_DSD_XH(void *handle, LSM6DS3_ACC_GYRO_DSD_XH_t *value);
 
 /*******************************************************************************
 * Register      : D6D_SRC
@@ -1982,7 +1982,7 @@ typedef enum
 } LSM6DS3_ACC_GYRO_DSD_YL_t;
 
 #define   LSM6DS3_ACC_GYRO_DSD_YL_MASK    0x04
-status_t LSM6DS3_ACC_GYRO_R_DSD_YL(void *handle, LSM6DS3_ACC_GYRO_DSD_YL_t *value);
+mems_status_t LSM6DS3_ACC_GYRO_R_DSD_YL(void *handle, LSM6DS3_ACC_GYRO_DSD_YL_t *value);
 
 /*******************************************************************************
 * Register      : D6D_SRC
@@ -1997,7 +1997,7 @@ typedef enum
 } LSM6DS3_ACC_GYRO_DSD_YH_t;
 
 #define   LSM6DS3_ACC_GYRO_DSD_YH_MASK    0x08
-status_t LSM6DS3_ACC_GYRO_R_DSD_YH(void *handle, LSM6DS3_ACC_GYRO_DSD_YH_t *value);
+mems_status_t LSM6DS3_ACC_GYRO_R_DSD_YH(void *handle, LSM6DS3_ACC_GYRO_DSD_YH_t *value);
 
 /*******************************************************************************
 * Register      : D6D_SRC
@@ -2012,7 +2012,7 @@ typedef enum
 } LSM6DS3_ACC_GYRO_DSD_ZL_t;
 
 #define   LSM6DS3_ACC_GYRO_DSD_ZL_MASK    0x10
-status_t LSM6DS3_ACC_GYRO_R_DSD_ZL(void *handle, LSM6DS3_ACC_GYRO_DSD_ZL_t *value);
+mems_status_t LSM6DS3_ACC_GYRO_R_DSD_ZL(void *handle, LSM6DS3_ACC_GYRO_DSD_ZL_t *value);
 
 /*******************************************************************************
 * Register      : D6D_SRC
@@ -2027,7 +2027,7 @@ typedef enum
 } LSM6DS3_ACC_GYRO_DSD_ZH_t;
 
 #define   LSM6DS3_ACC_GYRO_DSD_ZH_MASK    0x20
-status_t LSM6DS3_ACC_GYRO_R_DSD_ZH(void *handle, LSM6DS3_ACC_GYRO_DSD_ZH_t *value);
+mems_status_t LSM6DS3_ACC_GYRO_R_DSD_ZH(void *handle, LSM6DS3_ACC_GYRO_DSD_ZH_t *value);
 
 /*******************************************************************************
 * Register      : D6D_SRC
@@ -2042,7 +2042,7 @@ typedef enum
 } LSM6DS3_ACC_GYRO_D6D_EV_STATUS_t;
 
 #define   LSM6DS3_ACC_GYRO_D6D_EV_STATUS_MASK   0x40
-status_t LSM6DS3_ACC_GYRO_R_D6D_EV_STATUS(void *handle, LSM6DS3_ACC_GYRO_D6D_EV_STATUS_t *value);
+mems_status_t LSM6DS3_ACC_GYRO_R_D6D_EV_STATUS(void *handle, LSM6DS3_ACC_GYRO_D6D_EV_STATUS_t *value);
 
 /*******************************************************************************
 * Register      : STATUS_REG
@@ -2057,7 +2057,7 @@ typedef enum
 } LSM6DS3_ACC_GYRO_XLDA_t;
 
 #define   LSM6DS3_ACC_GYRO_XLDA_MASK    0x01
-status_t LSM6DS3_ACC_GYRO_R_XLDA(void *handle, LSM6DS3_ACC_GYRO_XLDA_t *value);
+mems_status_t LSM6DS3_ACC_GYRO_R_XLDA(void *handle, LSM6DS3_ACC_GYRO_XLDA_t *value);
 
 /*******************************************************************************
 * Register      : STATUS_REG
@@ -2072,7 +2072,7 @@ typedef enum
 } LSM6DS3_ACC_GYRO_GDA_t;
 
 #define   LSM6DS3_ACC_GYRO_GDA_MASK   0x02
-status_t LSM6DS3_ACC_GYRO_R_GDA(void *handle, LSM6DS3_ACC_GYRO_GDA_t *value);
+mems_status_t LSM6DS3_ACC_GYRO_R_GDA(void *handle, LSM6DS3_ACC_GYRO_GDA_t *value);
 
 /*******************************************************************************
 * Register      : STATUS_REG
@@ -2087,7 +2087,7 @@ typedef enum
 } LSM6DS3_ACC_GYRO_TDA_t;
 
 #define   LSM6DS3_ACC_GYRO_TDA_MASK   0x04
-status_t LSM6DS3_ACC_GYRO_R_TDA(void *handle, LSM6DS3_ACC_GYRO_TDA_t *value);
+mems_status_t LSM6DS3_ACC_GYRO_R_TDA(void *handle, LSM6DS3_ACC_GYRO_TDA_t *value);
 
 /*******************************************************************************
 * Register      : STATUS_REG
@@ -2102,7 +2102,7 @@ typedef enum
 } LSM6DS3_ACC_GYRO_EV_BOOT_t;
 
 #define   LSM6DS3_ACC_GYRO_EV_BOOT_MASK   0x08
-status_t LSM6DS3_ACC_GYRO_R_EV_BOOT(void *handle, LSM6DS3_ACC_GYRO_EV_BOOT_t *value);
+mems_status_t LSM6DS3_ACC_GYRO_R_EV_BOOT(void *handle, LSM6DS3_ACC_GYRO_EV_BOOT_t *value);
 
 /*******************************************************************************
 * Register      : FIFO_STATUS1
@@ -2114,7 +2114,7 @@ status_t LSM6DS3_ACC_GYRO_R_EV_BOOT(void *handle, LSM6DS3_ACC_GYRO_EV_BOOT_t *va
 #define   LSM6DS3_ACC_GYRO_DIFF_FIFO_STATUS1_POSITION   0
 #define   LSM6DS3_ACC_GYRO_DIFF_FIFO_STATUS2_MASK  0xF
 #define   LSM6DS3_ACC_GYRO_DIFF_FIFO_STATUS2_POSITION   0
-status_t LSM6DS3_ACC_GYRO_R_FIFONumOfEntries(void *handle, u16_t *value);
+mems_status_t LSM6DS3_ACC_GYRO_R_FIFONumOfEntries(void *handle, u16_t *value);
 
 /*******************************************************************************
 * Register      : FIFO_STATUS2
@@ -2129,7 +2129,7 @@ typedef enum
 } LSM6DS3_ACC_GYRO_FIFO_EMPTY_t;
 
 #define   LSM6DS3_ACC_GYRO_FIFO_EMPTY_MASK    0x10
-status_t LSM6DS3_ACC_GYRO_R_FIFOEmpty(void *handle, LSM6DS3_ACC_GYRO_FIFO_EMPTY_t *value);
+mems_status_t LSM6DS3_ACC_GYRO_R_FIFOEmpty(void *handle, LSM6DS3_ACC_GYRO_FIFO_EMPTY_t *value);
 
 /*******************************************************************************
 * Register      : FIFO_STATUS2
@@ -2144,7 +2144,7 @@ typedef enum
 } LSM6DS3_ACC_GYRO_FIFO_FULL_t;
 
 #define   LSM6DS3_ACC_GYRO_FIFO_FULL_MASK   0x20
-status_t LSM6DS3_ACC_GYRO_R_FIFOFull(void *handle, LSM6DS3_ACC_GYRO_FIFO_FULL_t *value);
+mems_status_t LSM6DS3_ACC_GYRO_R_FIFOFull(void *handle, LSM6DS3_ACC_GYRO_FIFO_FULL_t *value);
 
 /*******************************************************************************
 * Register      : FIFO_STATUS2
@@ -2159,7 +2159,7 @@ typedef enum
 } LSM6DS3_ACC_GYRO_OVERRUN_t;
 
 #define   LSM6DS3_ACC_GYRO_OVERRUN_MASK   0x40
-status_t LSM6DS3_ACC_GYRO_R_OVERRUN(void *handle, LSM6DS3_ACC_GYRO_OVERRUN_t *value);
+mems_status_t LSM6DS3_ACC_GYRO_R_OVERRUN(void *handle, LSM6DS3_ACC_GYRO_OVERRUN_t *value);
 
 /*******************************************************************************
 * Register      : FIFO_STATUS2
@@ -2174,7 +2174,7 @@ typedef enum
 } LSM6DS3_ACC_GYRO_WTM_t;
 
 #define   LSM6DS3_ACC_GYRO_WTM_MASK   0x80
-status_t LSM6DS3_ACC_GYRO_R_WaterMark(void *handle, LSM6DS3_ACC_GYRO_WTM_t *value);
+mems_status_t LSM6DS3_ACC_GYRO_R_WaterMark(void *handle, LSM6DS3_ACC_GYRO_WTM_t *value);
 
 /*******************************************************************************
 * Register      : FIFO_STATUS3
@@ -2186,7 +2186,7 @@ status_t LSM6DS3_ACC_GYRO_R_WaterMark(void *handle, LSM6DS3_ACC_GYRO_WTM_t *valu
 #define   LSM6DS3_ACC_GYRO_FIFO_STATUS3_PATTERN_POSITION    0
 #define   LSM6DS3_ACC_GYRO_FIFO_STATUS4_PATTERN_MASK    0x03
 #define   LSM6DS3_ACC_GYRO_FIFO_STATUS4_PATTERN_POSITION    0
-status_t LSM6DS3_ACC_GYRO_R_FIFOPattern(void *handle, u16_t *value);
+mems_status_t LSM6DS3_ACC_GYRO_R_FIFOPattern(void *handle, u16_t *value);
 
 /*******************************************************************************
 * Register      : FUNC_SRC
@@ -2201,7 +2201,7 @@ typedef enum
 } LSM6DS3_ACC_GYRO_SENS_HUB_END_t;
 
 #define   LSM6DS3_ACC_GYRO_SENS_HUB_END_MASK    0x01
-status_t LSM6DS3_ACC_GYRO_R_SENS_HUB_END(void *handle, LSM6DS3_ACC_GYRO_SENS_HUB_END_t *value);
+mems_status_t LSM6DS3_ACC_GYRO_R_SENS_HUB_END(void *handle, LSM6DS3_ACC_GYRO_SENS_HUB_END_t *value);
 
 /*******************************************************************************
 * Register      : FUNC_SRC
@@ -2216,7 +2216,7 @@ typedef enum
 } LSM6DS3_ACC_GYRO_SOFT_IRON_END_t;
 
 #define   LSM6DS3_ACC_GYRO_SOFT_IRON_END_MASK   0x02
-status_t LSM6DS3_ACC_GYRO_R_SOFT_IRON_END(void *handle, LSM6DS3_ACC_GYRO_SOFT_IRON_END_t *value);
+mems_status_t LSM6DS3_ACC_GYRO_R_SOFT_IRON_END(void *handle, LSM6DS3_ACC_GYRO_SOFT_IRON_END_t *value);
 
 /*******************************************************************************
 * Register      : FUNC_SRC
@@ -2231,7 +2231,7 @@ typedef enum
 } LSM6DS3_ACC_GYRO_STEP_OVERFLOW_t;
 
 #define   LSM6DS3_ACC_GYRO_STEP_OVERFLOW_MASK   0x08
-status_t LSM6DS3_ACC_GYRO_R_STEP_OVERFLOW(void *handle, LSM6DS3_ACC_GYRO_STEP_OVERFLOW_t *value);
+mems_status_t LSM6DS3_ACC_GYRO_R_STEP_OVERFLOW(void *handle, LSM6DS3_ACC_GYRO_STEP_OVERFLOW_t *value);
 
 /*******************************************************************************
 * Register      : FUNC_SRC
@@ -2246,7 +2246,7 @@ typedef enum
 } LSM6DS3_ACC_GYRO_STEP_COUNT_DELTA_t;
 
 #define   LSM6DS3_ACC_GYRO_STEP_COUNT_DELTA_MASK    0x08
-status_t LSM6DS3_ACC_GYRO_R_STEP_COUNT_DELTA(void *handle, LSM6DS3_ACC_GYRO_STEP_COUNT_DELTA_t *value);
+mems_status_t LSM6DS3_ACC_GYRO_R_STEP_COUNT_DELTA(void *handle, LSM6DS3_ACC_GYRO_STEP_COUNT_DELTA_t *value);
 
 
 
@@ -2263,7 +2263,7 @@ typedef enum
 } LSM6DS3_ACC_GYRO_PEDO_EV_STATUS_t;
 
 #define   LSM6DS3_ACC_GYRO_PEDO_EV_STATUS_MASK    0x10
-status_t LSM6DS3_ACC_GYRO_R_PEDO_EV_STATUS(void *handle, LSM6DS3_ACC_GYRO_PEDO_EV_STATUS_t *value);
+mems_status_t LSM6DS3_ACC_GYRO_R_PEDO_EV_STATUS(void *handle, LSM6DS3_ACC_GYRO_PEDO_EV_STATUS_t *value);
 
 /*******************************************************************************
 * Register      : FUNC_SRC
@@ -2278,7 +2278,7 @@ typedef enum
 } LSM6DS3_ACC_GYRO_TILT_EV_STATUS_t;
 
 #define   LSM6DS3_ACC_GYRO_TILT_EV_STATUS_MASK    0x20
-status_t LSM6DS3_ACC_GYRO_R_TILT_EV_STATUS(void *handle, LSM6DS3_ACC_GYRO_TILT_EV_STATUS_t *value);
+mems_status_t LSM6DS3_ACC_GYRO_R_TILT_EV_STATUS(void *handle, LSM6DS3_ACC_GYRO_TILT_EV_STATUS_t *value);
 
 /*******************************************************************************
 * Register      : FUNC_SRC
@@ -2293,7 +2293,7 @@ typedef enum
 } LSM6DS3_ACC_GYRO_SIGN_MOT_EV_STATUS_t;
 
 #define   LSM6DS3_ACC_GYRO_SIGN_MOT_EV_STATUS_MASK    0x40
-status_t LSM6DS3_ACC_GYRO_R_SIGN_MOT_EV_STATUS(void *handle, LSM6DS3_ACC_GYRO_SIGN_MOT_EV_STATUS_t *value);
+mems_status_t LSM6DS3_ACC_GYRO_R_SIGN_MOT_EV_STATUS(void *handle, LSM6DS3_ACC_GYRO_SIGN_MOT_EV_STATUS_t *value);
 
 /*******************************************************************************
 * Register      : TAP_CFG1
@@ -2308,8 +2308,8 @@ typedef enum
 } LSM6DS3_ACC_GYRO_LIR_t;
 
 #define   LSM6DS3_ACC_GYRO_LIR_MASK   0x01
-status_t  LSM6DS3_ACC_GYRO_W_LIR(void *handle, LSM6DS3_ACC_GYRO_LIR_t newValue);
-status_t LSM6DS3_ACC_GYRO_R_LIR(void *handle, LSM6DS3_ACC_GYRO_LIR_t *value);
+mems_status_t  LSM6DS3_ACC_GYRO_W_LIR(void *handle, LSM6DS3_ACC_GYRO_LIR_t newValue);
+mems_status_t LSM6DS3_ACC_GYRO_R_LIR(void *handle, LSM6DS3_ACC_GYRO_LIR_t *value);
 
 /*******************************************************************************
 * Register      : TAP_CFG1
@@ -2324,8 +2324,8 @@ typedef enum
 } LSM6DS3_ACC_GYRO_TAP_Z_EN_t;
 
 #define   LSM6DS3_ACC_GYRO_TAP_Z_EN_MASK    0x02
-status_t  LSM6DS3_ACC_GYRO_W_TAP_Z_EN(void *handle, LSM6DS3_ACC_GYRO_TAP_Z_EN_t newValue);
-status_t LSM6DS3_ACC_GYRO_R_TAP_Z_EN(void *handle, LSM6DS3_ACC_GYRO_TAP_Z_EN_t *value);
+mems_status_t  LSM6DS3_ACC_GYRO_W_TAP_Z_EN(void *handle, LSM6DS3_ACC_GYRO_TAP_Z_EN_t newValue);
+mems_status_t LSM6DS3_ACC_GYRO_R_TAP_Z_EN(void *handle, LSM6DS3_ACC_GYRO_TAP_Z_EN_t *value);
 
 /*******************************************************************************
 * Register      : TAP_CFG1
@@ -2340,8 +2340,8 @@ typedef enum
 } LSM6DS3_ACC_GYRO_TAP_Y_EN_t;
 
 #define   LSM6DS3_ACC_GYRO_TAP_Y_EN_MASK    0x04
-status_t  LSM6DS3_ACC_GYRO_W_TAP_Y_EN(void *handle, LSM6DS3_ACC_GYRO_TAP_Y_EN_t newValue);
-status_t LSM6DS3_ACC_GYRO_R_TAP_Y_EN(void *handle, LSM6DS3_ACC_GYRO_TAP_Y_EN_t *value);
+mems_status_t  LSM6DS3_ACC_GYRO_W_TAP_Y_EN(void *handle, LSM6DS3_ACC_GYRO_TAP_Y_EN_t newValue);
+mems_status_t LSM6DS3_ACC_GYRO_R_TAP_Y_EN(void *handle, LSM6DS3_ACC_GYRO_TAP_Y_EN_t *value);
 
 /*******************************************************************************
 * Register      : TAP_CFG1
@@ -2356,8 +2356,8 @@ typedef enum
 } LSM6DS3_ACC_GYRO_TAP_X_EN_t;
 
 #define   LSM6DS3_ACC_GYRO_TAP_X_EN_MASK    0x08
-status_t  LSM6DS3_ACC_GYRO_W_TAP_X_EN(void *handle, LSM6DS3_ACC_GYRO_TAP_X_EN_t newValue);
-status_t LSM6DS3_ACC_GYRO_R_TAP_X_EN(void *handle, LSM6DS3_ACC_GYRO_TAP_X_EN_t *value);
+mems_status_t  LSM6DS3_ACC_GYRO_W_TAP_X_EN(void *handle, LSM6DS3_ACC_GYRO_TAP_X_EN_t newValue);
+mems_status_t LSM6DS3_ACC_GYRO_R_TAP_X_EN(void *handle, LSM6DS3_ACC_GYRO_TAP_X_EN_t *value);
 
 /*******************************************************************************
 * Register      : TAP_CFG1
@@ -2372,8 +2372,8 @@ typedef enum
 } LSM6DS3_ACC_GYRO_TILT_EN_t;
 
 #define   LSM6DS3_ACC_GYRO_TILT_EN_MASK   0x20
-status_t  LSM6DS3_ACC_GYRO_W_TILT_EN(void *handle, LSM6DS3_ACC_GYRO_TILT_EN_t newValue);
-status_t LSM6DS3_ACC_GYRO_R_TILT_EN(void *handle, LSM6DS3_ACC_GYRO_TILT_EN_t *value);
+mems_status_t  LSM6DS3_ACC_GYRO_W_TILT_EN(void *handle, LSM6DS3_ACC_GYRO_TILT_EN_t newValue);
+mems_status_t LSM6DS3_ACC_GYRO_R_TILT_EN(void *handle, LSM6DS3_ACC_GYRO_TILT_EN_t *value);
 
 /*******************************************************************************
 * Register      : TAP_CFG1
@@ -2388,8 +2388,8 @@ typedef enum
 } LSM6DS3_ACC_GYRO_SLOPE_FDS_t;
 
 #define   LSM6DS3_ACC_GYRO_SLOPE_FDS_MASK   0x10
-status_t  LSM6DS3_ACC_GYRO_W_SLOPE_FDS(void *handle, LSM6DS3_ACC_GYRO_SLOPE_FDS_t newValue);
-status_t LSM6DS3_ACC_GYRO_R_SLOPE_FDS(void *handle, LSM6DS3_ACC_GYRO_SLOPE_FDS_t *value);
+mems_status_t  LSM6DS3_ACC_GYRO_W_SLOPE_FDS(void *handle, LSM6DS3_ACC_GYRO_SLOPE_FDS_t newValue);
+mems_status_t LSM6DS3_ACC_GYRO_R_SLOPE_FDS(void *handle, LSM6DS3_ACC_GYRO_SLOPE_FDS_t *value);
 
 /*******************************************************************************
 * Register      : TAP_CFG1
@@ -2404,8 +2404,8 @@ typedef enum
 } LSM6DS3_ACC_GYRO_PEDO_EN_t;
 
 #define   LSM6DS3_ACC_GYRO_PEDO_EN_MASK   0x40
-status_t  LSM6DS3_ACC_GYRO_W_PEDO_EN(void *handle, LSM6DS3_ACC_GYRO_PEDO_EN_t newValue);
-status_t LSM6DS3_ACC_GYRO_R_PEDO_EN(void *handle, LSM6DS3_ACC_GYRO_PEDO_EN_t *value);
+mems_status_t  LSM6DS3_ACC_GYRO_W_PEDO_EN(void *handle, LSM6DS3_ACC_GYRO_PEDO_EN_t newValue);
+mems_status_t LSM6DS3_ACC_GYRO_R_PEDO_EN(void *handle, LSM6DS3_ACC_GYRO_PEDO_EN_t *value);
 
 /*******************************************************************************
 * Register      : TAP_CFG1
@@ -2420,8 +2420,8 @@ typedef enum
 } LSM6DS3_ACC_GYRO_TIMER_EN_t;
 
 #define   LSM6DS3_ACC_GYRO_TIMER_EN_MASK    0x80
-status_t  LSM6DS3_ACC_GYRO_W_TIMER_EN(void *handle, LSM6DS3_ACC_GYRO_TIMER_EN_t newValue);
-status_t LSM6DS3_ACC_GYRO_R_TIMER_EN(void *handle, LSM6DS3_ACC_GYRO_TIMER_EN_t *value);
+mems_status_t  LSM6DS3_ACC_GYRO_W_TIMER_EN(void *handle, LSM6DS3_ACC_GYRO_TIMER_EN_t newValue);
+mems_status_t LSM6DS3_ACC_GYRO_R_TIMER_EN(void *handle, LSM6DS3_ACC_GYRO_TIMER_EN_t *value);
 
 /*******************************************************************************
 * Register      : TAP_THS_6D
@@ -2431,8 +2431,8 @@ status_t LSM6DS3_ACC_GYRO_R_TIMER_EN(void *handle, LSM6DS3_ACC_GYRO_TIMER_EN_t *
 *******************************************************************************/
 #define   LSM6DS3_ACC_GYRO_TAP_THS_MASK   0x1F
 #define   LSM6DS3_ACC_GYRO_TAP_THS_POSITION   0
-status_t  LSM6DS3_ACC_GYRO_W_TAP_THS(void *handle, u8_t newValue);
-status_t LSM6DS3_ACC_GYRO_R_TAP_THS(void *handle, u8_t *value);
+mems_status_t  LSM6DS3_ACC_GYRO_W_TAP_THS(void *handle, u8_t newValue);
+mems_status_t LSM6DS3_ACC_GYRO_R_TAP_THS(void *handle, u8_t *value);
 
 /*******************************************************************************
 * Register      : TAP_THS_6D
@@ -2449,8 +2449,8 @@ typedef enum
 } LSM6DS3_ACC_GYRO_SIXD_THS_t;
 
 #define   LSM6DS3_ACC_GYRO_SIXD_THS_MASK    0x60
-status_t  LSM6DS3_ACC_GYRO_W_SIXD_THS(void *handle, LSM6DS3_ACC_GYRO_SIXD_THS_t newValue);
-status_t LSM6DS3_ACC_GYRO_R_SIXD_THS(void *handle, LSM6DS3_ACC_GYRO_SIXD_THS_t *value);
+mems_status_t  LSM6DS3_ACC_GYRO_W_SIXD_THS(void *handle, LSM6DS3_ACC_GYRO_SIXD_THS_t newValue);
+mems_status_t LSM6DS3_ACC_GYRO_R_SIXD_THS(void *handle, LSM6DS3_ACC_GYRO_SIXD_THS_t *value);
 
 /*******************************************************************************
 * Register      : TAP_THS_6D
@@ -2465,8 +2465,8 @@ typedef enum
 } LSM6DS3_ACC_GYRO_D4D_t;
 
 #define   LSM6DS3_ACC_GYRO_D4D_MASK   0x80
-status_t  LSM6DS3_ACC_GYRO_W_D4D(void *handle, LSM6DS3_ACC_GYRO_D4D_t newValue);
-status_t LSM6DS3_ACC_GYRO_R_D4D(void *handle, LSM6DS3_ACC_GYRO_D4D_t *value);
+mems_status_t  LSM6DS3_ACC_GYRO_W_D4D(void *handle, LSM6DS3_ACC_GYRO_D4D_t newValue);
+mems_status_t LSM6DS3_ACC_GYRO_R_D4D(void *handle, LSM6DS3_ACC_GYRO_D4D_t *value);
 
 /*******************************************************************************
 * Register      : INT_DUR2
@@ -2476,8 +2476,8 @@ status_t LSM6DS3_ACC_GYRO_R_D4D(void *handle, LSM6DS3_ACC_GYRO_D4D_t *value);
 *******************************************************************************/
 #define   LSM6DS3_ACC_GYRO_SHOCK_MASK   0x03
 #define   LSM6DS3_ACC_GYRO_SHOCK_POSITION   0
-status_t  LSM6DS3_ACC_GYRO_W_SHOCK_Duration(void *handle, u8_t newValue);
-status_t LSM6DS3_ACC_GYRO_R_SHOCK_Duration(void *handle, u8_t *value);
+mems_status_t  LSM6DS3_ACC_GYRO_W_SHOCK_Duration(void *handle, u8_t newValue);
+mems_status_t LSM6DS3_ACC_GYRO_R_SHOCK_Duration(void *handle, u8_t *value);
 
 /*******************************************************************************
 * Register      : INT_DUR2
@@ -2487,8 +2487,8 @@ status_t LSM6DS3_ACC_GYRO_R_SHOCK_Duration(void *handle, u8_t *value);
 *******************************************************************************/
 #define   LSM6DS3_ACC_GYRO_QUIET_MASK   0x0C
 #define   LSM6DS3_ACC_GYRO_QUIET_POSITION   2
-status_t  LSM6DS3_ACC_GYRO_W_QUIET_Duration(void *handle, u8_t newValue);
-status_t LSM6DS3_ACC_GYRO_R_QUIET_Duration(void *handle, u8_t *value);
+mems_status_t  LSM6DS3_ACC_GYRO_W_QUIET_Duration(void *handle, u8_t newValue);
+mems_status_t LSM6DS3_ACC_GYRO_R_QUIET_Duration(void *handle, u8_t *value);
 
 /*******************************************************************************
 * Register      : INT_DUR2
@@ -2498,8 +2498,8 @@ status_t LSM6DS3_ACC_GYRO_R_QUIET_Duration(void *handle, u8_t *value);
 *******************************************************************************/
 #define   LSM6DS3_ACC_GYRO_DUR_MASK   0xF0
 #define   LSM6DS3_ACC_GYRO_DUR_POSITION   4
-status_t  LSM6DS3_ACC_GYRO_W_DUR(void *handle, u8_t newValue);
-status_t LSM6DS3_ACC_GYRO_R_DUR(void *handle, u8_t *value);
+mems_status_t  LSM6DS3_ACC_GYRO_W_DUR(void *handle, u8_t newValue);
+mems_status_t LSM6DS3_ACC_GYRO_R_DUR(void *handle, u8_t *value);
 
 /*******************************************************************************
 * Register      : WAKE_UP_THS
@@ -2509,8 +2509,8 @@ status_t LSM6DS3_ACC_GYRO_R_DUR(void *handle, u8_t *value);
 *******************************************************************************/
 #define   LSM6DS3_ACC_GYRO_WK_THS_MASK    0x3F
 #define   LSM6DS3_ACC_GYRO_WK_THS_POSITION    0
-status_t  LSM6DS3_ACC_GYRO_W_WK_THS(void *handle, u8_t newValue);
-status_t LSM6DS3_ACC_GYRO_R_WK_THS(void *handle, u8_t *value);
+mems_status_t  LSM6DS3_ACC_GYRO_W_WK_THS(void *handle, u8_t newValue);
+mems_status_t LSM6DS3_ACC_GYRO_R_WK_THS(void *handle, u8_t *value);
 
 /*******************************************************************************
 * Register      : WAKE_UP_THS
@@ -2525,8 +2525,8 @@ typedef enum
 } LSM6DS3_ACC_GYRO_INACTIVITY_ON_t;
 
 #define   LSM6DS3_ACC_GYRO_INACTIVITY_ON_MASK   0x40
-status_t  LSM6DS3_ACC_GYRO_W_INACTIVITY_ON(void *handle, LSM6DS3_ACC_GYRO_INACTIVITY_ON_t newValue);
-status_t LSM6DS3_ACC_GYRO_R_INACTIVITY_ON(void *handle, LSM6DS3_ACC_GYRO_INACTIVITY_ON_t *value);
+mems_status_t  LSM6DS3_ACC_GYRO_W_INACTIVITY_ON(void *handle, LSM6DS3_ACC_GYRO_INACTIVITY_ON_t newValue);
+mems_status_t LSM6DS3_ACC_GYRO_R_INACTIVITY_ON(void *handle, LSM6DS3_ACC_GYRO_INACTIVITY_ON_t *value);
 
 /*******************************************************************************
 * Register      : WAKE_UP_THS
@@ -2541,8 +2541,8 @@ typedef enum
 } LSM6DS3_ACC_GYRO_SINGLE_DOUBLE_TAP_t;
 
 #define   LSM6DS3_ACC_GYRO_SINGLE_DOUBLE_TAP_MASK   0x80
-status_t  LSM6DS3_ACC_GYRO_W_SINGLE_DOUBLE_TAP_EV(void *handle, LSM6DS3_ACC_GYRO_SINGLE_DOUBLE_TAP_t newValue);
-status_t LSM6DS3_ACC_GYRO_R_SINGLE_DOUBLE_TAP_EV(void *handle, LSM6DS3_ACC_GYRO_SINGLE_DOUBLE_TAP_t *value);
+mems_status_t  LSM6DS3_ACC_GYRO_W_SINGLE_DOUBLE_TAP_EV(void *handle, LSM6DS3_ACC_GYRO_SINGLE_DOUBLE_TAP_t newValue);
+mems_status_t LSM6DS3_ACC_GYRO_R_SINGLE_DOUBLE_TAP_EV(void *handle, LSM6DS3_ACC_GYRO_SINGLE_DOUBLE_TAP_t *value);
 
 /*******************************************************************************
 * Register      : WAKE_UP_DUR
@@ -2552,8 +2552,8 @@ status_t LSM6DS3_ACC_GYRO_R_SINGLE_DOUBLE_TAP_EV(void *handle, LSM6DS3_ACC_GYRO_
 *******************************************************************************/
 #define   LSM6DS3_ACC_GYRO_SLEEP_DUR_MASK   0x0F
 #define   LSM6DS3_ACC_GYRO_SLEEP_DUR_POSITION   0
-status_t  LSM6DS3_ACC_GYRO_W_SLEEP_DUR(void *handle, u8_t newValue);
-status_t LSM6DS3_ACC_GYRO_R_SLEEP_DUR(void *handle, u8_t *value);
+mems_status_t  LSM6DS3_ACC_GYRO_W_SLEEP_DUR(void *handle, u8_t newValue);
+mems_status_t LSM6DS3_ACC_GYRO_R_SLEEP_DUR(void *handle, u8_t *value);
 
 /*******************************************************************************
 * Register      : WAKE_UP_DUR
@@ -2568,8 +2568,8 @@ typedef enum
 } LSM6DS3_ACC_GYRO_TIMER_HR_t;
 
 #define   LSM6DS3_ACC_GYRO_TIMER_HR_MASK    0x10
-status_t  LSM6DS3_ACC_GYRO_W_TIMER_HR(void *handle, LSM6DS3_ACC_GYRO_TIMER_HR_t newValue);
-status_t LSM6DS3_ACC_GYRO_R_TIMER_HR(void *handle, LSM6DS3_ACC_GYRO_TIMER_HR_t *value);
+mems_status_t  LSM6DS3_ACC_GYRO_W_TIMER_HR(void *handle, LSM6DS3_ACC_GYRO_TIMER_HR_t newValue);
+mems_status_t LSM6DS3_ACC_GYRO_R_TIMER_HR(void *handle, LSM6DS3_ACC_GYRO_TIMER_HR_t *value);
 
 /*******************************************************************************
 * Register      : WAKE_UP_DUR
@@ -2579,8 +2579,8 @@ status_t LSM6DS3_ACC_GYRO_R_TIMER_HR(void *handle, LSM6DS3_ACC_GYRO_TIMER_HR_t *
 *******************************************************************************/
 #define   LSM6DS3_ACC_GYRO_WAKE_DUR_MASK    0x60
 #define   LSM6DS3_ACC_GYRO_WAKE_DUR_POSITION    5
-status_t  LSM6DS3_ACC_GYRO_W_WAKE_DUR(void *handle, u8_t newValue);
-status_t LSM6DS3_ACC_GYRO_R_WAKE_DUR(void *handle, u8_t *value);
+mems_status_t  LSM6DS3_ACC_GYRO_W_WAKE_DUR(void *handle, u8_t newValue);
+mems_status_t LSM6DS3_ACC_GYRO_R_WAKE_DUR(void *handle, u8_t *value);
 
 /*******************************************************************************
 * Register      : FREE_FALL
@@ -2592,8 +2592,8 @@ status_t LSM6DS3_ACC_GYRO_R_WAKE_DUR(void *handle, u8_t *value);
 #define   LSM6DS3_ACC_GYRO_FF_FREE_FALL_DUR_POSITION    3
 #define   LSM6DS3_ACC_GYRO_FF_WAKE_UP_DUR_MASK    0x80
 #define   LSM6DS3_ACC_GYRO_FF_WAKE_UP_DUR_POSITION    7
-status_t  LSM6DS3_ACC_GYRO_W_FF_Duration(void *handle, u8_t newValue);
-status_t LSM6DS3_ACC_GYRO_R_FF_Duration(void *handle, u8_t *value);
+mems_status_t  LSM6DS3_ACC_GYRO_W_FF_Duration(void *handle, u8_t newValue);
+mems_status_t LSM6DS3_ACC_GYRO_R_FF_Duration(void *handle, u8_t *value);
 
 
 /*******************************************************************************
@@ -2615,8 +2615,8 @@ typedef enum
 } LSM6DS3_ACC_GYRO_FF_THS_t;
 
 #define   LSM6DS3_ACC_GYRO_FF_THS_MASK    0x07
-status_t  LSM6DS3_ACC_GYRO_W_FF_THS(void *handle, LSM6DS3_ACC_GYRO_FF_THS_t newValue);
-status_t LSM6DS3_ACC_GYRO_R_FF_THS(void *handle, LSM6DS3_ACC_GYRO_FF_THS_t *value);
+mems_status_t  LSM6DS3_ACC_GYRO_W_FF_THS(void *handle, LSM6DS3_ACC_GYRO_FF_THS_t newValue);
+mems_status_t LSM6DS3_ACC_GYRO_R_FF_THS(void *handle, LSM6DS3_ACC_GYRO_FF_THS_t *value);
 
 /*******************************************************************************
 * Register      : MD1_CFG
@@ -2631,8 +2631,8 @@ typedef enum
 } LSM6DS3_ACC_GYRO_INT1_TIMER_t;
 
 #define   LSM6DS3_ACC_GYRO_INT1_TIMER_MASK    0x01
-status_t  LSM6DS3_ACC_GYRO_W_TimerEvRouteInt1(void *handle, LSM6DS3_ACC_GYRO_INT1_TIMER_t newValue);
-status_t LSM6DS3_ACC_GYRO_R_TimerEvRouteInt1(void *handle, LSM6DS3_ACC_GYRO_INT1_TIMER_t *value);
+mems_status_t  LSM6DS3_ACC_GYRO_W_TimerEvRouteInt1(void *handle, LSM6DS3_ACC_GYRO_INT1_TIMER_t newValue);
+mems_status_t LSM6DS3_ACC_GYRO_R_TimerEvRouteInt1(void *handle, LSM6DS3_ACC_GYRO_INT1_TIMER_t *value);
 
 /*******************************************************************************
 * Register      : MD1_CFG
@@ -2647,8 +2647,8 @@ typedef enum
 } LSM6DS3_ACC_GYRO_INT1_TILT_t;
 
 #define   LSM6DS3_ACC_GYRO_INT1_TILT_MASK   0x02
-status_t  LSM6DS3_ACC_GYRO_W_TiltEvOnInt1(void *handle, LSM6DS3_ACC_GYRO_INT1_TILT_t newValue);
-status_t LSM6DS3_ACC_GYRO_R_TiltEvOnInt1(void *handle, LSM6DS3_ACC_GYRO_INT1_TILT_t *value);
+mems_status_t  LSM6DS3_ACC_GYRO_W_TiltEvOnInt1(void *handle, LSM6DS3_ACC_GYRO_INT1_TILT_t newValue);
+mems_status_t LSM6DS3_ACC_GYRO_R_TiltEvOnInt1(void *handle, LSM6DS3_ACC_GYRO_INT1_TILT_t *value);
 
 /*******************************************************************************
 * Register      : MD1_CFG
@@ -2663,8 +2663,8 @@ typedef enum
 } LSM6DS3_ACC_GYRO_INT1_6D_t;
 
 #define   LSM6DS3_ACC_GYRO_INT1_6D_MASK   0x04
-status_t  LSM6DS3_ACC_GYRO_W_6DEvOnInt1(void *handle, LSM6DS3_ACC_GYRO_INT1_6D_t newValue);
-status_t LSM6DS3_ACC_GYRO_R_6DEvOnInt1(void *handle, LSM6DS3_ACC_GYRO_INT1_6D_t *value);
+mems_status_t  LSM6DS3_ACC_GYRO_W_6DEvOnInt1(void *handle, LSM6DS3_ACC_GYRO_INT1_6D_t newValue);
+mems_status_t LSM6DS3_ACC_GYRO_R_6DEvOnInt1(void *handle, LSM6DS3_ACC_GYRO_INT1_6D_t *value);
 
 /*******************************************************************************
 * Register      : MD1_CFG
@@ -2679,8 +2679,8 @@ typedef enum
 } LSM6DS3_ACC_GYRO_INT1_TAP_t;
 
 #define   LSM6DS3_ACC_GYRO_INT1_TAP_MASK    0x08
-status_t  LSM6DS3_ACC_GYRO_W_TapEvOnInt1(void *handle, LSM6DS3_ACC_GYRO_INT1_TAP_t newValue);
-status_t LSM6DS3_ACC_GYRO_R_TapEvOnInt1(void *handle, LSM6DS3_ACC_GYRO_INT1_TAP_t *value);
+mems_status_t  LSM6DS3_ACC_GYRO_W_TapEvOnInt1(void *handle, LSM6DS3_ACC_GYRO_INT1_TAP_t newValue);
+mems_status_t LSM6DS3_ACC_GYRO_R_TapEvOnInt1(void *handle, LSM6DS3_ACC_GYRO_INT1_TAP_t *value);
 
 /*******************************************************************************
 * Register      : MD1_CFG
@@ -2695,8 +2695,8 @@ typedef enum
 } LSM6DS3_ACC_GYRO_INT1_FF_t;
 
 #define   LSM6DS3_ACC_GYRO_INT1_FF_MASK   0x10
-status_t  LSM6DS3_ACC_GYRO_W_FFEvOnInt1(void *handle, LSM6DS3_ACC_GYRO_INT1_FF_t newValue);
-status_t LSM6DS3_ACC_GYRO_R_FFEvOnInt1(void *handle, LSM6DS3_ACC_GYRO_INT1_FF_t *value);
+mems_status_t  LSM6DS3_ACC_GYRO_W_FFEvOnInt1(void *handle, LSM6DS3_ACC_GYRO_INT1_FF_t newValue);
+mems_status_t LSM6DS3_ACC_GYRO_R_FFEvOnInt1(void *handle, LSM6DS3_ACC_GYRO_INT1_FF_t *value);
 
 /*******************************************************************************
 * Register      : MD1_CFG
@@ -2711,8 +2711,8 @@ typedef enum
 } LSM6DS3_ACC_GYRO_INT1_WU_t;
 
 #define   LSM6DS3_ACC_GYRO_INT1_WU_MASK   0x20
-status_t  LSM6DS3_ACC_GYRO_W_WUEvOnInt1(void *handle, LSM6DS3_ACC_GYRO_INT1_WU_t newValue);
-status_t LSM6DS3_ACC_GYRO_R_WUEvOnInt1(void *handle, LSM6DS3_ACC_GYRO_INT1_WU_t *value);
+mems_status_t  LSM6DS3_ACC_GYRO_W_WUEvOnInt1(void *handle, LSM6DS3_ACC_GYRO_INT1_WU_t newValue);
+mems_status_t LSM6DS3_ACC_GYRO_R_WUEvOnInt1(void *handle, LSM6DS3_ACC_GYRO_INT1_WU_t *value);
 
 /*******************************************************************************
 * Register      : MD1_CFG
@@ -2727,8 +2727,8 @@ typedef enum
 } LSM6DS3_ACC_GYRO_INT1_SINGLE_TAP_t;
 
 #define   LSM6DS3_ACC_GYRO_INT1_SINGLE_TAP_MASK   0x40
-status_t  LSM6DS3_ACC_GYRO_W_SingleTapOnInt1(void *handle, LSM6DS3_ACC_GYRO_INT1_SINGLE_TAP_t newValue);
-status_t LSM6DS3_ACC_GYRO_R_SingleTapOnInt1(void *handle, LSM6DS3_ACC_GYRO_INT1_SINGLE_TAP_t *value);
+mems_status_t  LSM6DS3_ACC_GYRO_W_SingleTapOnInt1(void *handle, LSM6DS3_ACC_GYRO_INT1_SINGLE_TAP_t newValue);
+mems_status_t LSM6DS3_ACC_GYRO_R_SingleTapOnInt1(void *handle, LSM6DS3_ACC_GYRO_INT1_SINGLE_TAP_t *value);
 
 /*******************************************************************************
 * Register      : MD1_CFG
@@ -2743,8 +2743,8 @@ typedef enum
 } LSM6DS3_ACC_GYRO_INT1_SLEEP_t;
 
 #define   LSM6DS3_ACC_GYRO_INT1_SLEEP_MASK    0x80
-status_t  LSM6DS3_ACC_GYRO_W_SleepEvOnInt1(void *handle, LSM6DS3_ACC_GYRO_INT1_SLEEP_t newValue);
-status_t LSM6DS3_ACC_GYRO_R_SleepEvOnInt1(void *handle, LSM6DS3_ACC_GYRO_INT1_SLEEP_t *value);
+mems_status_t  LSM6DS3_ACC_GYRO_W_SleepEvOnInt1(void *handle, LSM6DS3_ACC_GYRO_INT1_SLEEP_t newValue);
+mems_status_t LSM6DS3_ACC_GYRO_R_SleepEvOnInt1(void *handle, LSM6DS3_ACC_GYRO_INT1_SLEEP_t *value);
 
 /*******************************************************************************
 * Register      : MD2_CFG
@@ -2759,8 +2759,8 @@ typedef enum
 } LSM6DS3_ACC_GYRO_INT2_TIMER_t;
 
 #define   LSM6DS3_ACC_GYRO_INT2_TIMER_MASK    0x01
-status_t  LSM6DS3_ACC_GYRO_W_TimerEvRouteInt2(void *handle, LSM6DS3_ACC_GYRO_INT2_TIMER_t newValue);
-status_t LSM6DS3_ACC_GYRO_R_TimerEvRouteInt2(void *handle, LSM6DS3_ACC_GYRO_INT2_TIMER_t *value);
+mems_status_t  LSM6DS3_ACC_GYRO_W_TimerEvRouteInt2(void *handle, LSM6DS3_ACC_GYRO_INT2_TIMER_t newValue);
+mems_status_t LSM6DS3_ACC_GYRO_R_TimerEvRouteInt2(void *handle, LSM6DS3_ACC_GYRO_INT2_TIMER_t *value);
 
 /*******************************************************************************
 * Register      : MD2_CFG
@@ -2775,8 +2775,8 @@ typedef enum
 } LSM6DS3_ACC_GYRO_INT2_TILT_t;
 
 #define   LSM6DS3_ACC_GYRO_INT2_TILT_MASK   0x02
-status_t  LSM6DS3_ACC_GYRO_W_TiltEvOnInt2(void *handle, LSM6DS3_ACC_GYRO_INT2_TILT_t newValue);
-status_t LSM6DS3_ACC_GYRO_R_TiltEvOnInt2(void *handle, LSM6DS3_ACC_GYRO_INT2_TILT_t *value);
+mems_status_t  LSM6DS3_ACC_GYRO_W_TiltEvOnInt2(void *handle, LSM6DS3_ACC_GYRO_INT2_TILT_t newValue);
+mems_status_t LSM6DS3_ACC_GYRO_R_TiltEvOnInt2(void *handle, LSM6DS3_ACC_GYRO_INT2_TILT_t *value);
 
 /*******************************************************************************
 * Register      : MD2_CFG
@@ -2791,8 +2791,8 @@ typedef enum
 } LSM6DS3_ACC_GYRO_INT2_6D_t;
 
 #define   LSM6DS3_ACC_GYRO_INT2_6D_MASK   0x04
-status_t  LSM6DS3_ACC_GYRO_W_6DEvOnInt2(void *handle, LSM6DS3_ACC_GYRO_INT2_6D_t newValue);
-status_t LSM6DS3_ACC_GYRO_R_6DEvOnInt2(void *handle, LSM6DS3_ACC_GYRO_INT2_6D_t *value);
+mems_status_t  LSM6DS3_ACC_GYRO_W_6DEvOnInt2(void *handle, LSM6DS3_ACC_GYRO_INT2_6D_t newValue);
+mems_status_t LSM6DS3_ACC_GYRO_R_6DEvOnInt2(void *handle, LSM6DS3_ACC_GYRO_INT2_6D_t *value);
 
 /*******************************************************************************
 * Register      : MD2_CFG
@@ -2807,8 +2807,8 @@ typedef enum
 } LSM6DS3_ACC_GYRO_INT2_TAP_t;
 
 #define   LSM6DS3_ACC_GYRO_INT2_TAP_MASK    0x08
-status_t  LSM6DS3_ACC_GYRO_W_TapEvOnInt2(void *handle, LSM6DS3_ACC_GYRO_INT2_TAP_t newValue);
-status_t LSM6DS3_ACC_GYRO_R_TapEvOnInt2(void *handle, LSM6DS3_ACC_GYRO_INT2_TAP_t *value);
+mems_status_t  LSM6DS3_ACC_GYRO_W_TapEvOnInt2(void *handle, LSM6DS3_ACC_GYRO_INT2_TAP_t newValue);
+mems_status_t LSM6DS3_ACC_GYRO_R_TapEvOnInt2(void *handle, LSM6DS3_ACC_GYRO_INT2_TAP_t *value);
 
 /*******************************************************************************
 * Register      : MD2_CFG
@@ -2823,8 +2823,8 @@ typedef enum
 } LSM6DS3_ACC_GYRO_INT2_FF_t;
 
 #define   LSM6DS3_ACC_GYRO_INT2_FF_MASK   0x10
-status_t  LSM6DS3_ACC_GYRO_W_FFEvOnInt2(void *handle, LSM6DS3_ACC_GYRO_INT2_FF_t newValue);
-status_t LSM6DS3_ACC_GYRO_R_FFEvOnInt2(void *handle, LSM6DS3_ACC_GYRO_INT2_FF_t *value);
+mems_status_t  LSM6DS3_ACC_GYRO_W_FFEvOnInt2(void *handle, LSM6DS3_ACC_GYRO_INT2_FF_t newValue);
+mems_status_t LSM6DS3_ACC_GYRO_R_FFEvOnInt2(void *handle, LSM6DS3_ACC_GYRO_INT2_FF_t *value);
 
 /*******************************************************************************
 * Register      : MD2_CFG
@@ -2839,8 +2839,8 @@ typedef enum
 } LSM6DS3_ACC_GYRO_INT2_WU_t;
 
 #define   LSM6DS3_ACC_GYRO_INT2_WU_MASK   0x20
-status_t  LSM6DS3_ACC_GYRO_W_WUEvOnInt2(void *handle, LSM6DS3_ACC_GYRO_INT2_WU_t newValue);
-status_t LSM6DS3_ACC_GYRO_R_WUEvOnInt2(void *handle, LSM6DS3_ACC_GYRO_INT2_WU_t *value);
+mems_status_t  LSM6DS3_ACC_GYRO_W_WUEvOnInt2(void *handle, LSM6DS3_ACC_GYRO_INT2_WU_t newValue);
+mems_status_t LSM6DS3_ACC_GYRO_R_WUEvOnInt2(void *handle, LSM6DS3_ACC_GYRO_INT2_WU_t *value);
 
 /*******************************************************************************
 * Register      : MD2_CFG
@@ -2855,8 +2855,8 @@ typedef enum
 } LSM6DS3_ACC_GYRO_INT2_SINGLE_TAP_t;
 
 #define   LSM6DS3_ACC_GYRO_INT2_SINGLE_TAP_MASK   0x40
-status_t  LSM6DS3_ACC_GYRO_W_SingleTapOnInt2(void *handle, LSM6DS3_ACC_GYRO_INT2_SINGLE_TAP_t newValue);
-status_t LSM6DS3_ACC_GYRO_R_SingleTapOnInt2(void *handle, LSM6DS3_ACC_GYRO_INT2_SINGLE_TAP_t *value);
+mems_status_t  LSM6DS3_ACC_GYRO_W_SingleTapOnInt2(void *handle, LSM6DS3_ACC_GYRO_INT2_SINGLE_TAP_t newValue);
+mems_status_t LSM6DS3_ACC_GYRO_R_SingleTapOnInt2(void *handle, LSM6DS3_ACC_GYRO_INT2_SINGLE_TAP_t *value);
 
 /*******************************************************************************
 * Register      : MD2_CFG
@@ -2871,8 +2871,8 @@ typedef enum
 } LSM6DS3_ACC_GYRO_INT2_SLEEP_t;
 
 #define   LSM6DS3_ACC_GYRO_INT2_SLEEP_MASK    0x80
-status_t  LSM6DS3_ACC_GYRO_W_SleepEvOnInt2(void *handle, LSM6DS3_ACC_GYRO_INT2_SLEEP_t newValue);
-status_t LSM6DS3_ACC_GYRO_R_SleepEvOnInt2(void *handle, LSM6DS3_ACC_GYRO_INT2_SLEEP_t *value);
+mems_status_t  LSM6DS3_ACC_GYRO_W_SleepEvOnInt2(void *handle, LSM6DS3_ACC_GYRO_INT2_SLEEP_t newValue);
+mems_status_t LSM6DS3_ACC_GYRO_R_SleepEvOnInt2(void *handle, LSM6DS3_ACC_GYRO_INT2_SLEEP_t *value);
 
 
 
@@ -2881,36 +2881,36 @@ status_t LSM6DS3_ACC_GYRO_R_SleepEvOnInt2(void *handle, LSM6DS3_ACC_GYRO_INT2_SL
 * Output Type   : GetFIFOData
 * Permission    : RO
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_Get_GetFIFOData(void *handle, u8_t *buff);
+mems_status_t LSM6DS3_ACC_GYRO_Get_GetFIFOData(void *handle, u8_t *buff);
 /*******************************************************************************
 * Register      : <REGISTER_L> - <REGISTER_H>
 * Output Type   : GetTimestamp
 * Permission    : RO
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_Get_GetTimestamp(void *handle, u8_t *buff);
+mems_status_t LSM6DS3_ACC_GYRO_Get_GetTimestamp(void *handle, u8_t *buff);
 /*******************************************************************************
 * Register      : <REGISTER_L> - <REGISTER_H>
 * Output Type   : GetStepCounter
 * Permission    : RO
 *******************************************************************************/
-status_t LSM6DS3_ACC_GYRO_Get_GetStepCounter(void *handle, u8_t *buff);
+mems_status_t LSM6DS3_ACC_GYRO_Get_GetStepCounter(void *handle, u8_t *buff);
 
 /************** Program Pedometer Threshold  *******************/
-status_t  LSM6DS3_ACC_GYRO_W_PedoThreshold(void *handle, u8_t newValue);
+mems_status_t  LSM6DS3_ACC_GYRO_W_PedoThreshold(void *handle, u8_t newValue);
 
 /************** Use Sensor Hub  *******************/
 
 /* program to .... */
-status_t LSM6DS3_ACC_GYRO_SH0_Program(void *handle, u8_t SlvAddr, u8_t Reg, u8_t len);
+mems_status_t LSM6DS3_ACC_GYRO_SH0_Program(void *handle, u8_t SlvAddr, u8_t Reg, u8_t len);
 
 /* Program the six Soft Iron Matrix coefficients. */
-status_t LSM6DS3_ACC_GYRO_SH_init_SI_Matrix(void *handle, u8_t *SI_matrix);
+mems_status_t LSM6DS3_ACC_GYRO_SH_init_SI_Matrix(void *handle, u8_t *SI_matrix);
 
 /* Read a remote device through I2C Sensor Hub Slave 0 */
-status_t LSM6DS3_ACC_GYRO_SH0_ReadMem(void *handle, u8_t SlvAddr, u8_t Reg, u8_t *Bufp, u8_t len, u8_t stop);
+mems_status_t LSM6DS3_ACC_GYRO_SH0_ReadMem(void *handle, u8_t SlvAddr, u8_t Reg, u8_t *Bufp, u8_t len, u8_t stop);
 
 /* Write a remote device through I2C Sensor Hub Slave 0 */
-status_t LSM6DS3_ACC_GYRO_SH0_WriteByte(void *handle, u8_t SlvAddr, u8_t Reg, u8_t Bufp);
+mems_status_t LSM6DS3_ACC_GYRO_SH0_WriteByte(void *handle, u8_t SlvAddr, u8_t Reg, u8_t Bufp);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Hi all,
I would like to apply this patch because "status_t" name is too generic and it can cause conflicts of multiple definitions with other X-NUCLEO libraries. The patch does not break any compatibility with high level APIs, so it should be safe.
Best Regards,
Carlo